### PR TITLE
Fix missing NC library error

### DIFF
--- a/_core/lib/nc/config-default.pl
+++ b/_core/lib/nc/config-default.pl
@@ -9,4 +9,7 @@ our $title = 'ゆとシートⅡ for Nechronica';
 our $skin_tmpl  = $::core_dir . '/skin/nc/index.html';
 our $skin_sheet = $::core_dir . '/skin/nc/sheet-chara.html';
 
+# 一覧表示用ライブラリ
+our $lib_list_char = $::core_dir . '/lib/nc/list-chara.pl';
+
 1;

--- a/_core/lib/nc/list-chara.pl
+++ b/_core/lib/nc/list-chara.pl
@@ -1,0 +1,8 @@
+use strict;
+use utf8;
+use open ":utf8";
+
+print "Content-Type: text/html\n\n";
+print "<html><body><p>Nechronica版のキャラクター一覧は現在未実装です。</p></body></html>";
+
+1;


### PR DESCRIPTION
## Summary
- define `lib_list_char` in `nc/config-default.pl`
- implement stub library `nc/list-chara.pl` to avoid require errors

## Testing
- `perl -c _core/lib/nc/list-chara.pl`

------
https://chatgpt.com/codex/tasks/task_e_684807b9123c8330ab7ea65b74779060