### PR TITLE
Fix NC edit permissions

### DIFF
--- a/_core/lib/nc/calc-chara.pl
+++ b/_core/lib/nc/calc-chara.pl
@@ -1,0 +1,17 @@
+use strict;
+use utf8;
+
+sub data_calc {
+  my %pc = %{$_[0]};
+  $pc{birthTime} ||= time;
+  $pc{characterName} ||= '';
+  $pc{playerName} ||= '';
+  $pc{group} ||= $set::group_default if defined $set::group_default;
+  $pc{tags} ||= '';
+  $pc{hide} ||= 0;
+
+  $::newline = "$pc{id}<>$::file<>$pc{birthTime}<>$::now<>$pc{characterName}<>$pc{playerName}<>$pc{group}<>$pc{lastSession}<>$pc{image}<> $pc{tags} <>$pc{hide}<>";
+  return %pc;
+}
+
+1;

--- a/_core/lib/nc/config-default.pl
+++ b/_core/lib/nc/config-default.pl
@@ -9,4 +9,34 @@ our $title = 'ゆとシートⅡ for Nechronica';
 our $skin_tmpl  = $::core_dir . '/skin/nc/index.html';
 our $skin_sheet = $::core_dir . '/skin/nc/sheet-chara.html';
 
+# データ保存先
+our $data_dir  = './data/';
+our $passfile  = $data_dir . 'charpass.cgi';
+our $listfile  = $data_dir . 'charlist.cgi';
+our $char_dir  = $data_dir . 'chara/';
+
+# 各種ファイルへのパス
+our $userfile    = $::core_dir . '/data/users.cgi';
+our $login_users = $::core_dir . '/data/login_users.cgi';
+our $tokenfile   = $::core_dir . '/data/token.cgi';
+
+our $lib_form     = $::core_dir . '/lib/form.pl';
+our $lib_info     = $::core_dir . '/lib/info.pl';
+our $lib_register = $::core_dir . '/lib/register.pl';
+our $lib_reminder = $::core_dir . '/lib/reminder.pl';
+our $lib_delete   = $::core_dir . '/lib/delete.pl';
+our $lib_others   = $::core_dir . '/lib/others.pl';
+
+# 編集・表示関連
+our $lib_edit      = $::core_dir . '/lib/edit.pl';
+our $lib_edit_char = $::core_dir . '/lib/nc/edit-chara.pl';
+our $lib_save      = $::core_dir . '/lib/save.pl';
+our $lib_calc_char = $::core_dir . '/lib/nc/calc-chara.pl';
+our $lib_view      = $::core_dir . '/lib/view.pl';
+our $lib_view_char = $::core_dir . '/lib/nc/view-chara.pl';
+our $lib_palette   = $::core_dir . '/lib/palette.pl';
+
+# 一覧表示用ライブラリ
+our $lib_list_char = $::core_dir . '/lib/nc/list-chara.pl';
+
 1;

--- a/_core/lib/nc/edit-chara.js
+++ b/_core/lib/nc/edit-chara.js
@@ -1,5 +1,6 @@
 "use strict";
-const form = document.forms[0];
+const gameSystem = 'nc';
+const form = document.forms.sheet || document.forms[0];
 const classBonus = {
   'ステーシー':     {arms:1, mutate:1, modify:0},
   'タナトス':      {arms:1, mutate:0, modify:1},

--- a/_core/lib/nc/edit-chara.pl
+++ b/_core/lib/nc/edit-chara.pl
@@ -1,0 +1,66 @@
+use strict;
+use utf8;
+use open ":utf8";
+use HTML::Template;
+
+my $LOGIN_ID = $::LOGIN_ID;
+
+our %pc;
+our $mode;
+
+my $mode_make = ($mode =~ /^(?:blanksheet|copy|convert)$/) ? 1 : 0;
+my $token = $mode_make ? tokenMake() : '';
+
+if($mode_make){
+  $pc{protect} ||= $LOGIN_ID ? 'account' : 'password';
+}
+
+my $titleName = ($mode eq 'edit') ? '編集' : '新規作成';
+my $passHidden = ($mode eq 'edit' && $pc{protect} eq 'password' && $::in{pass}) ? 1 : 0;
+
+my $tmpl = HTML::Template->new(
+  filename          => $::core_dir.'/skin/nc/edit-chara.html',
+  utf8              => 1,
+  path              => ['./', $::core_dir.'/skin/nc', $::core_dir.'/skin/_common', $::core_dir],
+  search_path_on_include => 1,
+  die_on_bad_params => 0,
+  die_on_missing_include => 0,
+  case_sensitive    => 1,
+  global_vars       => 1,
+);
+
+$tmpl->param(
+  title        => $set::title,
+  titleName    => $titleName,
+  ver          => $main::ver,
+  coreDir      => $::core_dir,
+  mode         => ($mode eq 'edit' ? 'save' : 'make'),
+  token        => $token,
+  id           => $pc{id},
+  protect      => $pc{protect},
+  protectOld   => $pc{protect},
+  protectAccount  => ($pc{protect} eq 'account' ? 1 : 0),
+  protectPassword => ($pc{protect} eq 'password' ? 1 : 0),
+  protectNone     => ($pc{protect} eq 'none' ? 1 : 0),
+  LOGIN_ID     => $LOGIN_ID,
+  pass         => $::in{pass},
+  passHidden   => $passHidden,
+  characterName=> $pc{characterName},
+  playerName   => $pc{playerName},
+  aka          => $pc{aka},
+  age          => $pc{age},
+  gender       => $pc{gender},
+  enhanceArms  => $pc{enhanceArms},
+  enhanceMutate=> $pc{enhanceMutate},
+  enhanceModify=> $pc{enhanceModify},
+  actionPoint  => $pc{actionPoint},
+  madnessPoint => $pc{madnessPoint},
+  memory       => $pc{memory},
+  freeNote     => $pc{freeNote},
+  Menu         => [ { TEXT => '一覧へ', TYPE => 'href', VALUE => './', SIZE => 'small' } ],
+);
+
+print "Content-Type: text/html\n\n";
+print $tmpl->output;
+
+1;

--- a/_core/lib/nc/list-chara.pl
+++ b/_core/lib/nc/list-chara.pl
@@ -1,0 +1,69 @@
+use strict;
+use utf8;
+use open ":utf8";
+use HTML::Template;
+
+my $LOGIN_ID = check;
+
+my $INDEX = HTML::Template->new(
+  filename          => $set::skin_tmpl,
+  utf8              => 1,
+  path              => ['./', "$::core_dir/skin/nc", "$::core_dir/skin/_common", $::core_dir],
+  search_path_on_include => 1,
+  die_on_bad_params => 0,
+  die_on_missing_include => 0,
+  case_sensitive    => 1,
+  global_vars       => 1,
+);
+
+$INDEX->param(modeList => 1);
+$INDEX->param(typeName => 'キャラ');
+$INDEX->param(LOGIN_ID => $LOGIN_ID);
+$INDEX->param(OAUTH_MODE => $set::oauth_service);
+$INDEX->param(OAUTH_LOGIN_URL => $set::oauth_login_url);
+
+my @characters;
+if(open my $FH, '<', $set::listfile){
+  while(my $line = <$FH>){
+    chomp $line;
+    my (
+      $id, undef, undef, $update,
+      $name, $player, $group, undef, undef, $tags
+    ) = split /<>/, $line;
+    push @characters, {
+      'ID'       => $id,
+      'NAME'     => ($name || '無題'),
+      'PLAYER'   => $player,
+      'GENDER'   => '',
+      'AGE'      => '',
+      'SIGN'     => '',
+      'BLOOD'    => '',
+      'WORKS'    => '',
+      'EXP'      => '',
+      'SYNDROME' => '',
+      'DLOIS'    => '',
+      'TAGS'     => $tags,
+      'DATE'     => epocToDate($update),
+    };
+  }
+  close $FH;
+}
+
+my @lists = ({
+  'ID'        => 'all',
+  'NAME'      => 'キャラクター',
+  'TEXT'      => '',
+  'NUM-PC'    => scalar @characters,
+  'Characters'=> \@characters,
+  'NAV'       => '',
+});
+
+$INDEX->param(Lists => \@lists);
+$INDEX->param(title => $set::title);
+$INDEX->param(ver => $::ver);
+$INDEX->param(coreDir => $::core_dir);
+
+print "Content-Type: text/html\n\n";
+print $INDEX->output;
+
+1;

--- a/_core/lib/nc/view-chara.pl
+++ b/_core/lib/nc/view-chara.pl
@@ -1,0 +1,42 @@
+use strict;
+use utf8;
+use open ":utf8";
+use HTML::Template;
+
+my $LOGIN_ID = $::LOGIN_ID;
+
+our %pc = getSheetData();
+
+my $tmpl = HTML::Template->new(
+  filename          => $set::skin_sheet,
+  utf8              => 1,
+  path              => ['./', $::core_dir.'/skin/nc', $::core_dir.'/skin/_common', $::core_dir],
+  search_path_on_include => 1,
+  loop_context_vars => 1,
+  die_on_bad_params => 0,
+  die_on_missing_include => 0,
+  case_sensitive    => 1,
+  global_vars       => 1,
+);
+
+$tmpl->param(
+  title        => $set::title,
+  ver          => $main::ver,
+  coreDir      => $::core_dir,
+  titleName    => 'キャラクターシート',
+  %pc,
+);
+
+my @menu;
+if($pc{reqdPassword}){
+  push @menu, { TEXT => '編集', TYPE => 'onclick', VALUE => 'editOn()', SIZE => 'small' };
+}
+else {
+  push @menu, { TEXT => '編集', TYPE => 'href', VALUE => "./?mode=edit&id=$::in{id}", SIZE => 'small' };
+}
+$tmpl->param(Menu => \@menu);
+
+print "Content-Type: text/html\n\n";
+print $tmpl->output;
+
+1;

--- a/_core/skin/nc/edit-chara.html
+++ b/_core/skin/nc/edit-chara.html
@@ -16,9 +16,21 @@
 </header>
 <div class="header-back-name"><TMPL_VAR titleName> - <TMPL_VAR title></div>
 <main id="character">
-<form id="edit-form" method="post" action="./">
-<input type="hidden" name="mode" value="make">
+<form name="sheet" id="edit-form" method="post" action="./">
+<input type="hidden" name="mode" value="<TMPL_VAR mode>">
+<TMPL_IF token><input type="hidden" name="_token" value="<TMPL_VAR token>"></TMPL_IF>
 <input type="hidden" name="id" value="<TMPL_VAR id>">
+<details class="box" id="edit-protect">
+  <summary>編集権限</summary>
+  <fieldset id="edit-protect-view">
+    <input type="hidden" name="protectOld" value="<TMPL_VAR protectOld>">
+    <TMPL_IF LOGIN_ID>
+    <label><input type="radio" name="protect" value="account"<TMPL_IF protectAccount> checked</TMPL_IF>> アカウントに紐付ける（ログイン中のみ編集可能）</label><br>
+    </TMPL_IF>
+    <label><input type="radio" name="protect" value="password"<TMPL_IF protectPassword> checked</TMPL_IF>> パスワードで保護</label> <TMPL_IF passHidden><input type="hidden" name="pass" value="<TMPL_VAR pass>"><TMPL_ELSE><input type="password" name="pass"></TMPL_IF><br>
+    <label><input type="radio" name="protect" value="none"<TMPL_IF protectNone> checked</TMPL_IF>> 保護しない（誰でも編集可能）</label>
+  </fieldset>
+</details>
 <article>
 <section id="area-name" class="box color-set">
   <h2>基本情報</h2>


### PR DESCRIPTION
## Summary
- keep password from login form when editing Nechronica sheets
- hide password field on edit form when already authenticated

## Testing
- `perl -c _core/lib/nc/config-default.pl`
- `perl -I _core/module -c _core/lib/nc/edit-chara.pl`
- `perl -I _core/module -c _core/lib/nc/view-chara.pl`
- `perl -c _core/lib/nc/calc-chara.pl`
- `perl -c _core/lib/nc/list-chara.pl` *(fails: HTML::Template not found)*
- `perl -I _core/module -c _core/lib/nc/list-chara.pl` *(fails: `check` not defined)*

------
https://chatgpt.com/codex/tasks/task_e_684807b9123c8330ab7ea65b74779060