### PR TITLE
Implement groups & tags for NC, remove codename

### DIFF
--- a/_core/lib/nc/config-default.pl
+++ b/_core/lib/nc/config-default.pl
@@ -43,4 +43,12 @@ our $image_maxsize = 1024 * 1024 * 1;
 # 一覧表示用ライブラリ
 our $lib_list_char = $::core_dir . '/lib/nc/list-chara.pl';
 
+## ●グループ関連
+our @groups = (
+  ['pc',  '01', 'ＰＣ', 'プレイヤーキャラクター'],
+  ['npc', '99', 'ＮＰＣ', 'ノンプレイヤーキャラクター'],
+);
+
+our $group_default = 'pc';
+
 1;

--- a/_core/lib/nc/edit-chara.pl
+++ b/_core/lib/nc/edit-chara.pl
@@ -26,7 +26,11 @@ $pc{enhanceArmsGrow}   ||= 0;
 $pc{enhanceMutateGrow} ||= 0;
 $pc{enhanceModifyGrow} ||= 0;
 $pc{enhanceAny}       ||= '';
-$pc{maneuverNum}      ||= 1;
+$pc{maneuverNum}      ||= 3;
+$pc{forbidden}        ||= '';
+$pc{group}            ||= $set::group_default if defined $set::group_default;
+$pc{tags}             ||= '';
+$pc{hide}             ||= 0;
 
 my @classes = (
   'ステーシー','タナトス','ゴシック','レクイエム','バロック','ロマネスク','サイケデリック'
@@ -41,6 +45,13 @@ my %any_checked = (
   mutate => ($pc{enhanceAny} eq 'mutate' ? 'checked' : ''),
   modify => ($pc{enhanceAny} eq 'modify' ? 'checked' : ''),
 );
+
+my @groups;
+foreach (@set::groups){
+  my ($id, undef, $name, undef, $exclusive) = @$_;
+  next if($exclusive && (!$LOGIN_ID || $LOGIN_ID !~ /^($exclusive)$/));
+  push @groups, { ID=>$id, NAME=>$name, SELECTED=>($pc{group} eq $id ? 1:0) };
+}
 
 my @maneuver_rows;
 foreach my $i (1 .. $pc{maneuverNum}){
@@ -100,7 +111,6 @@ $tmpl->param(
   passHidden   => $passHidden,
   characterName=> $pc{characterName},
   playerName   => $pc{playerName},
-  aka          => $pc{aka},
   age          => $pc{age},
   gender       => $pc{gender},
   enhanceArms  => $pc{enhanceArms},
@@ -115,6 +125,10 @@ $tmpl->param(
   imageForm    => $imageForm,
   memory       => $pc{memory},
   freeNote     => $pc{freeNote},
+  forbidden    => $pc{forbidden},
+  hide         => $pc{hide},
+  group        => $pc{group},
+  tags         => $pc{tags},
   map { ("mainClassSelected".($_+1) => $main_selected{$_+1}) } 0..$#classes,
   map { ("subClassSelected" .($_+1) => $sub_selected{$_+1})  } 0..$#classes,
   enhanceAnyArms   => $any_checked{arms},
@@ -122,6 +136,9 @@ $tmpl->param(
   enhanceAnyModify => $any_checked{modify},
   maneuverNum   => $pc{maneuverNum},
   ManeuverRows  => \@maneuver_rows,
+  Groups       => \@groups,
+  forbiddenBattle => ($pc{forbidden} eq 'battle' ? 1 : 0),
+  forbiddenAll    => ($pc{forbidden} eq 'all'    ? 1 : 0),
   Menu         => [ { TEXT => '一覧へ', TYPE => 'href', VALUE => './', SIZE => 'small' } ],
 );
 

--- a/_core/lib/nc/view-chara.pl
+++ b/_core/lib/nc/view-chara.pl
@@ -1,4 +1,5 @@
 use strict;
+use subs qw/existsRow/;
 use utf8;
 use open ":utf8";
 use HTML::Template;
@@ -19,7 +20,7 @@ my $tmpl = HTML::Template->new(
   global_vars       => 1,
 );
 
-$pc{maneuverNum} ||= 1;
+$pc{maneuverNum} ||= 3;
 my @maneuvers;
 foreach my $i (1 .. $pc{maneuverNum}){
   next if !existsRow "maneuver$i",'Name','Timing','Cost','Range','Note';
@@ -35,12 +36,24 @@ foreach my $i (1 .. $pc{maneuverNum}){
   };
 }
 
+if(!$pc{group}){
+  $pc{group} = $set::group_default;
+}
+my $group_name = '';
+foreach (@set::groups){
+  if($pc{group} eq @$_[0]){ $group_name = @$_[2]; last; }
+}
+my @tags;
+foreach(split(/ /, $pc{tags})){ push @tags, { URL => uri_escape_utf8($_), TEXT => $_ }; }
+
 $tmpl->param(
   title        => $set::title,
   ver          => $main::ver,
   coreDir      => $::core_dir,
   titleName    => 'キャラクターシート',
   %pc,
+  groupName   => $group_name,
+  Tags        => \@tags,
   Maneuvers   => \@maneuvers,
 );
 

--- a/_core/skin/nc/css/chara.css
+++ b/_core/skin/nc/css/chara.css
@@ -11,6 +11,10 @@ article {
   grid-gap: 1rem;
 }
 
+#area-name, #tags {
+  grid-column: span 2;
+}
+
 #area-status {
   display: grid;
   grid-template-columns: 1fr 1fr;

--- a/_core/skin/nc/edit-chara.html
+++ b/_core/skin/nc/edit-chara.html
@@ -24,7 +24,7 @@
 </header>
 <div class="header-back-name"><TMPL_VAR titleName> - <TMPL_VAR title></div>
 <main id="character">
-<form name="sheet" id="edit-form" method="post" action="./">
+<form name="sheet" id="edit-form" method="post" action="./" enctype="multipart/form-data">
 <input type="hidden" name="mode" value="<TMPL_VAR mode>">
 <TMPL_IF token><input type="hidden" name="_token" value="<TMPL_VAR token>"></TMPL_IF>
 <input type="hidden" name="id" value="<TMPL_VAR id>">
@@ -39,15 +39,44 @@
     <label><input type="radio" name="protect" value="none"<TMPL_IF protectNone> checked</TMPL_IF>> 保護しない（誰でも編集可能）</label>
   </fieldset>
 </details>
-<article>
-<section id="area-name" class="box color-set">
-  <h2>基本情報</h2>
+<dl class="box" id="hide-options">
+  <dt>閲覧可否設定</dt>
+  <dd id="forbidden-checkbox">
+    <select name="forbidden">
+      <option value="">内容を全て開示
+      <option value="battle" <TMPL_IF forbiddenBattle>selected</TMPL_IF>>データ・数値のみ秘匿
+      <option value="all"    <TMPL_IF forbiddenAll>selected</TMPL_IF>>内容を全て秘匿
+    </select>
+  </dd>
+  <dd id="hide-checkbox">
+    <select name="hide">
+      <option value="">一覧に表示
+      <option value="1" <TMPL_IF hide>selected</TMPL_IF>>一覧には非表示
+    </select>
+  </dd>
+  <dd>※「一覧に非表示」でもタグ検索結果・マイリストには表示されます</dd>
+</dl>
+<div class="box" id="group">
   <dl>
-    <dt>キャラクター名<dd><input type="text" name="characterName" value="<TMPL_VAR characterName>">
-    <dt>プレイヤー名<dd><input type="text" name="playerName" value="<TMPL_VAR playerName>">
-    <dt>コードネーム<dd><input type="text" name="aka" value="<TMPL_VAR aka>">
+    <dt>グループ<dd><select name="group">
+      <TMPL_LOOP Groups><option value="<TMPL_VAR ID>"<TMPL_IF SELECTED> selected</TMPL_IF>><TMPL_VAR NAME></option></TMPL_LOOP>
+    </select>
+    <dt>タグ<dd><input type="text" name="tags" value="<TMPL_VAR tags>">
   </dl>
-</section>
+</div>
+<div class="box in-toc" id="name-form" data-content-title="キャラクター名・プレイヤー名">
+  <div>
+    <dl id="character-name">
+      <dt>キャラクター名
+      <dd><input type="text" name="characterName" value="<TMPL_VAR characterName>">
+    </dl>
+  </div>
+  <dl id="player-name">
+    <dt>プレイヤー名
+    <dd><input type="text" name="playerName" value="<TMPL_VAR playerName>">
+  </dl>
+</div>
+<article>
 <section id="area-status" class="box">
   <h2>ステータス</h2>
   <TMPL_VAR imageForm>

--- a/_core/skin/nc/sheet-chara.html
+++ b/_core/skin/nc/sheet-chara.html
@@ -17,11 +17,16 @@
 <main id="character">
 <article>
   <div id="area-name" class="color-set">
-    <h1 id="character-name"><TMPL_IF aka>“<TMPL_VAR aka>”</TMPL_IF><TMPL_VAR characterName></h1>
+    <h1 id="character-name"><TMPL_VAR characterName></h1>
     <div>
       <p id="update-time"><time><TMPL_VAR updateTime></time></p>
       <p id="player-name">プレイヤー：<TMPL_VAR playerName></p>
     </div>
+  </div>
+
+  <div id="tags">
+    <TMPL_IF group><a id="group" href="./?group=<TMPL_VAR group>"><TMPL_VAR groupName></a></TMPL_IF>
+    <TMPL_LOOP Tags><a class="tag" href="./?tag=<TMPL_VAR URL>"><TMPL_VAR TEXT></a></TMPL_LOOP>
   </div>
 
   <div id="area-status">


### PR DESCRIPTION
## Summary
- add group definitions for NC
- store and handle forbidden, hide, group and tag settings
- remove codename field from NC sheets
- display tags and group links on character sheet
- adjust default maneuver rows and related CSS
- fix compile error in view script and allow file uploads

## Testing
- `perl -I./_core/module -I./_core/lib -c _core/lib/nc/edit-chara.pl`
- `perl -I./_core/module -I./_core/lib -c _core/lib/nc/view-chara.pl`

------
https://chatgpt.com/codex/tasks/task_e_68496c989c9c83308866c5fce5a9efe5