### PR TITLE
Fix NC session handling and maneuver rows

### DIFF
--- a/_core/lib/nc/config-default.pl
+++ b/_core/lib/nc/config-default.pl
@@ -18,7 +18,10 @@ our $char_dir  = $data_dir . 'chara/';
 # 各種ファイルへのパス
 our $userfile    = $::core_dir . '/data/users.cgi';
 our $login_users = $::core_dir . '/data/login_users.cgi';
-our $tokenfile   = $::core_dir . '/data/token.cgi';
+# 一時トークン保存ファイル
+# デフォルトではコアディレクトリに保存されますが、書き込み権限の都合で
+# エラーになる場合があるため、Nechronica用データディレクトリに変更
+our $tokenfile   = './data/token.cgi';
 
 our $lib_form     = $::core_dir . '/lib/form.pl';
 our $lib_info     = $::core_dir . '/lib/info.pl';

--- a/_core/lib/nc/edit-chara.js
+++ b/_core/lib/nc/edit-chara.js
@@ -46,6 +46,10 @@ window.addEventListener('DOMContentLoaded',()=>{
   });
   imagePosition();
   setSortable('maneuver','#maneuver-table tbody','tr');
+  if(!document.querySelector('#maneuver-list tr')){
+    const num = Number(form.maneuverNum.value) || 0;
+    for(let i=0; i<num; i++){ addManeuver(); }
+  }
 });
 
 // マニューバ欄 ----------------------------------------

--- a/_core/lib/nc/view-chara.pl
+++ b/_core/lib/nc/view-chara.pl
@@ -23,7 +23,6 @@ my $tmpl = HTML::Template->new(
 $pc{maneuverNum} ||= 3;
 my @maneuvers;
 foreach my $i (1 .. $pc{maneuverNum}){
-  next if !existsRow "maneuver$i",'Name','Timing','Cost','Range','Note';
   push @maneuvers, {
     BROKEN => ($pc{"maneuverBroken$i"} ? '☑' : ''),
     USED   => ($pc{"maneuverUsed$i"}  ? '☑' : ''),

--- a/_core/lib/subroutine.pl
+++ b/_core/lib/subroutine.pl
@@ -266,7 +266,7 @@ sub random_id {
 sub token_check {
   my $in_token = shift;
   my $flag = 0;
-  open (my $FH, '+<', $set::tokenfile);
+  sysopen(my $FH, $set::tokenfile, O_RDWR | O_CREAT, 0666) or return 0;
   flock($FH, 2);
   my @list = <$FH>;
   seek($FH, 0, 0);


### PR DESCRIPTION
## Summary
- create token file if missing during session check
- auto-add maneuver rows when none exist

## Testing
- `perl -c _core/lib/nc/config-default.pl`
- `perl -c _core/lib/nc/view-chara.pl`
- `perl -c _core/lib/subroutine.pl`
- `perl -c _core/lib/nc/edit-chara.pl`


------
https://chatgpt.com/codex/tasks/task_e_684975a2e6d48330ae414cb7ce2873db