### PR TITLE
Add memory and fetter sections to NC

### DIFF
--- a/_core/lib/nc/calc-chara.pl
+++ b/_core/lib/nc/calc-chara.pl
@@ -10,6 +10,22 @@ sub data_calc {
   $pc{tags} ||= '';
   $pc{hide} ||= 0;
 
+  ### 記憶のカケラ
+  $pc{memoryNum} ||= 2;
+  $pc{memoryNum} = 6 if $pc{memoryNum} > 6;
+  foreach my $i (1 .. $pc{memoryNum}){
+    $pc{"memoryName$i"} ||= '';
+    $pc{"memoryNote$i"} ||= '';
+  }
+
+  ### 未練／狂気
+  foreach my $i (1 .. 6){
+    $pc{"fetterTarget$i"} ||= '';
+    $pc{"fetterNote$i"}   ||= '';
+    $pc{"fetterEffect$i"} ||= '';
+    $pc{"fetterPoint$i"}  ||= ($i == 1 ? 3 : '');
+  }
+
   $pc{enhanceAny} ||= '';
   $pc{enhanceArmsGrow}   ||= 0;
   $pc{enhanceMutateGrow} ||= 0;

--- a/_core/lib/nc/config-default.pl
+++ b/_core/lib/nc/config-default.pl
@@ -21,7 +21,9 @@ our $login_users = $::core_dir . '/data/login_users.cgi';
 # 一時トークン保存ファイル
 # デフォルトではコアディレクトリに保存されますが、書き込み権限の都合で
 # エラーになる場合があるため、Nechronica用データディレクトリに変更
-our $tokenfile   = './data/token.cgi';
+## 一時トークン保存ファイル
+## 他システムと同様にコアディレクトリ配下を使用
+our $tokenfile   = $::core_dir . '/data/token.cgi';
 
 our $lib_form     = $::core_dir . '/lib/form.pl';
 our $lib_info     = $::core_dir . '/lib/info.pl';

--- a/_core/lib/nc/edit-chara.js
+++ b/_core/lib/nc/edit-chara.js
@@ -50,6 +50,11 @@ window.addEventListener('DOMContentLoaded',()=>{
     const num = Number(form.maneuverNum.value) || 0;
     for(let i=0; i<num; i++){ addManeuver(); }
   }
+  setSortable('memory','#memory-table tbody','tr');
+  if(!document.querySelector('#memory-list tr')){
+    const num = Number(form.memoryNum.value) || 0;
+    for(let i=0; i<num; i++){ addMemory(); }
+  }
 });
 
 // マニューバ欄 ----------------------------------------
@@ -58,4 +63,12 @@ function addManeuver(){
 }
 function delManeuver(){
   delRow('maneuverNum', '#maneuver-table tbody:last-of-type');
+}
+
+// 記憶のカケラ欄 ----------------------------------------
+function addMemory(){
+  document.querySelector('#memory-table tbody').append(createRow('memory','memoryNum',6));
+}
+function delMemory(){
+  delRow('memoryNum', '#memory-table tbody:last-of-type',2);
 }

--- a/_core/lib/nc/edit-chara.pl
+++ b/_core/lib/nc/edit-chara.pl
@@ -27,6 +27,11 @@ $pc{enhanceMutateGrow} ||= 0;
 $pc{enhanceModifyGrow} ||= 0;
 $pc{enhanceAny}       ||= '';
 $pc{maneuverNum}      ||= 3;
+$pc{memoryNum}        ||= 2;
+foreach my $i (1 .. 6){
+  $pc{"fetterPoint$i"} ||= ($i == 1 ? 3 : '');
+}
+$pc{memoryNum}        ||= 2;
 $pc{forbidden}        ||= '';
 $pc{group}            ||= $set::group_default if defined $set::group_default;
 $pc{tags}             ||= '';
@@ -77,6 +82,26 @@ foreach my $i (1 .. $pc{maneuverNum}){
   };
 }
 
+my @memory_rows;
+foreach my $i (1 .. $pc{memoryNum}){
+  push @memory_rows, {
+    ID   => $i,
+    NAME => $pc{"memoryName$i"},
+    NOTE => $pc{"memoryNote$i"},
+  };
+}
+
+my @fetter_rows;
+foreach my $i (1 .. 6){
+  push @fetter_rows, {
+    ID     => $i,
+    TARGET => $pc{"fetterTarget$i"},
+    NOTE   => $pc{"fetterNote$i"},
+    EFFECT => $pc{"fetterEffect$i"},
+    POINT  => $pc{"fetterPoint$i"},
+  };
+}
+
 my $titleName = ($mode eq 'edit') ? '編集' : '新規作成';
 my $passHidden = ($mode eq 'edit' && $pc{protect} eq 'password' && $::in{pass}) ? 1 : 0;
 
@@ -123,7 +148,9 @@ $tmpl->param(
   madnessPoint => $pc{madnessPoint},
   imageURL     => $pc{imageURL},
   imageForm    => $imageForm,
-  memory       => $pc{memory},
+  memoryNum    => $pc{memoryNum},
+  MemoryRows   => \@memory_rows,
+  FetterRows   => \@fetter_rows,
   freeNote     => $pc{freeNote},
   forbidden    => $pc{forbidden},
   hide         => $pc{hide},

--- a/_core/lib/nc/view-chara.pl
+++ b/_core/lib/nc/view-chara.pl
@@ -35,6 +35,29 @@ foreach my $i (1 .. $pc{maneuverNum}){
   };
 }
 
+$pc{memoryNum} ||= 0;
+my @memory_rows;
+foreach my $i (1 .. $pc{memoryNum}){
+  push @memory_rows, {
+    NAME => $pc{"memoryName$i"},
+    NOTE => $pc{"memoryNote$i"},
+  };
+}
+
+my @fetter_rows;
+foreach my $i (1 .. 6){
+  my $p = $pc{"fetterPoint$i"} || 0;
+  my $mark = '○○○○';
+  substr($mark,0,$p) = '●' x $p;
+  push @fetter_rows, {
+    TARGET    => $pc{"fetterTarget$i"},
+    NOTE      => $pc{"fetterNote$i"},
+    EFFECT    => $pc{"fetterEffect$i"},
+    POINT     => $p,
+    POINT_MARK=> $mark,
+  };
+}
+
 if(!$pc{group}){
   $pc{group} = $set::group_default;
 }
@@ -54,6 +77,8 @@ $tmpl->param(
   groupName   => $group_name,
   Tags        => \@tags,
   Maneuvers   => \@maneuvers,
+  MemoryRows  => \@memory_rows,
+  FetterRows  => \@fetter_rows,
 );
 
 my @menu;

--- a/_core/skin/nc/edit-chara.html
+++ b/_core/skin/nc/edit-chara.html
@@ -229,8 +229,46 @@
   </template>
 </section>
 <section id="memory" class="box">
-  <h2>メモリー</h2>
-  <textarea name="memory" rows="4"><TMPL_VAR memory></textarea>
+  <h2>記憶のカケラ</h2>
+  <input type="hidden" name="memoryNum" value="<TMPL_VAR memoryNum>">
+  <table class="edit-table no-border-cells" id="memory-table">
+    <thead>
+      <tr><th>名称<th class="left">内容</tr>
+    </thead>
+    <tbody id="memory-list">
+<TMPL_LOOP MemoryRows>
+      <tr id="memory-row<TMPL_VAR ID>">
+        <td><input type="text" name="memoryName<TMPL_VAR ID>" value="<TMPL_VAR NAME>"></td>
+        <td><input type="text" name="memoryNote<TMPL_VAR ID>" value="<TMPL_VAR NOTE>"></td>
+      </tr>
+</TMPL_LOOP>
+    </tbody>
+  </table>
+  <div class="add-del-button"><a onclick="addMemory()">▼</a><a onclick="delMemory()">▲</a></div>
+  <template id="memory-template">
+    <tr id="memory-rowTMPL">
+      <td><input type="text" name="memoryNameTMPL"></td>
+      <td><input type="text" name="memoryNoteTMPL"></td>
+    </tr>
+  </template>
+</section>
+<section id="fetters" class="box">
+  <h2>未練／狂気</h2>
+  <table class="edit-table no-border-cells" id="fetters-table">
+    <thead>
+      <tr><th>未練対象<th>未練内容<th>発狂効果<th>狂気点</tr>
+    </thead>
+    <tbody>
+<TMPL_LOOP FetterRows>
+      <tr>
+        <td><input type="text" name="fetterTarget<TMPL_VAR ID>" value="<TMPL_VAR TARGET>"></td>
+        <td><input type="text" name="fetterNote<TMPL_VAR ID>" value="<TMPL_VAR NOTE>"></td>
+        <td><input type="text" name="fetterEffect<TMPL_VAR ID>" value="<TMPL_VAR EFFECT>"></td>
+        <td><input type="number" name="fetterPoint<TMPL_VAR ID>" value="<TMPL_VAR POINT>" min="0" max="4"></td>
+      </tr>
+</TMPL_LOOP>
+    </tbody>
+  </table>
 </section>
 <section id="free-note" class="box">
   <h2>自由メモ</h2>

--- a/_core/skin/nc/sheet-chara.html
+++ b/_core/skin/nc/sheet-chara.html
@@ -98,8 +98,36 @@
   </section>
 
   <section id="memory" class="box">
-    <h2>メモリー</h2>
-    <div id="memory-note"><TMPL_VAR memory></div>
+    <h2>記憶のカケラ</h2>
+    <table>
+      <thead>
+        <tr><th>名称<th class="left">内容</tr>
+      </thead>
+      <tbody>
+<TMPL_LOOP MemoryRows>
+        <tr><td><TMPL_VAR NAME></td><td><TMPL_VAR NOTE></td></tr>
+</TMPL_LOOP>
+      </tbody>
+    </table>
+  </section>
+
+  <section id="fetters" class="box">
+    <h2>未練／狂気</h2>
+    <table>
+      <thead>
+        <tr><th>未練対象<th>未練内容<th>発狂効果<th>狂気点</tr>
+      </thead>
+      <tbody>
+<TMPL_LOOP FetterRows>
+        <tr>
+          <td><TMPL_VAR TARGET></td>
+          <td><TMPL_VAR NOTE></td>
+          <td><TMPL_VAR EFFECT></td>
+          <td><TMPL_VAR POINT_MARK></td>
+        </tr>
+</TMPL_LOOP>
+      </tbody>
+    </table>
   </section>
 
   <section id="free-note" class="box">


### PR DESCRIPTION
## Summary
- add tokenfile fix for NC system
- support memory fragments and fetters fields in NC character sheets
- update edit/view templates and JS

## Testing
- `perl -c _core/lib/nc/calc-chara.pl`
- `perl -c _core/lib/nc/edit-chara.pl` *(fails: Missing HTML::Template)*
- `perl -c _core/lib/nc/view-chara.pl` *(fails: Missing HTML::Template)*

------
https://chatgpt.com/codex/tasks/task_e_684982a8275883308b40c09b6d8b2961