### PR TITLE
Fix NC sheet template error

### DIFF
--- a/_core/lib/nc/view-chara.pl
+++ b/_core/lib/nc/view-chara.pl
@@ -8,6 +8,13 @@ my $LOGIN_ID = $::LOGIN_ID;
 
 our %pc = getSheetData();
 
+# 任意選択ボーナスの表示用
+my %enhance_any_mark = (
+  arms   => ($pc{enhanceAny} eq 'arms'   ? '+1' : ''),
+  mutate => ($pc{enhanceAny} eq 'mutate' ? '+1' : ''),
+  modify => ($pc{enhanceAny} eq 'modify' ? '+1' : ''),
+);
+
 my $tmpl = HTML::Template->new(
   filename          => $set::skin_sheet,
   utf8              => 1,
@@ -79,6 +86,9 @@ $tmpl->param(
   Maneuvers   => \@maneuvers,
   MemoryRows  => \@memory_rows,
   FetterRows  => \@fetter_rows,
+  enhanceAnyArms   => $enhance_any_mark{arms},
+  enhanceAnyMutate => $enhance_any_mark{mutate},
+  enhanceAnyModify => $enhance_any_mark{modify},
 );
 
 my @menu;

--- a/_core/skin/nc/css/chara.css
+++ b/_core/skin/nc/css/chara.css
@@ -23,6 +23,7 @@ article {
 #personal {
   display: flex;
   gap: .5rem;
+  flex-wrap: wrap;
 }
 #personal dl {
   flex: 1;

--- a/_core/skin/nc/css/edit.css
+++ b/_core/skin/nc/css/edit.css
@@ -55,6 +55,7 @@ body:not([data-create-type="F"]) .fullscratch-only {
 #personal {
   display: flex;
   gap: .5em;
+  flex-wrap: wrap;
 }
 #personal dl {
   flex: 1;

--- a/_core/skin/nc/edit-chara.html
+++ b/_core/skin/nc/edit-chara.html
@@ -81,8 +81,8 @@
   <h2>ステータス</h2>
   <TMPL_VAR imageForm>
   <div id="personal" class="box-union">
-    <dl class="box"><dt>年齢<dd><input type="text" name="age" value="<TMPL_VAR age>"></dl>
-    <dl class="box"><dt>性別<dd><input type="text" name="gender" value="<TMPL_VAR gender>"></dl>
+    <dl class="box" id="age"><dt>年齢<dd><input type="text" name="age" value="<TMPL_VAR age>"></dl>
+    <dl class="box" id="gender"><dt>性別<dd><input type="text" name="gender" value="<TMPL_VAR gender>"></dl>
   </div>
   <table id="class-enhance" class="edit-table">
     <thead>

--- a/_core/skin/nc/sheet-chara.html
+++ b/_core/skin/nc/sheet-chara.html
@@ -32,8 +32,8 @@
   <div id="area-status">
     <div id="image" class="image" style="background-image:url(<TMPL_VAR imageSrc>);"></div>
     <div id="personal" class="box-union">
-      <dl class="box"><dt>年齢<dd><TMPL_VAR age></dl>
-      <dl class="box"><dt>性別<dd><TMPL_VAR gender></dl>
+      <dl class="box" id="age"><dt>年齢<dd><TMPL_VAR age></dl>
+      <dl class="box" id="gender"><dt>性別<dd><TMPL_VAR gender></dl>
     </div>
     <div id="renegade" class="box">
       <table id="class-enhance" class="data-table">
@@ -63,9 +63,9 @@
           </tr>
           <tr>
             <th colspan="2">任意選択ボーナス</th>
-            <td><TMPL_IF enhanceAny eq 'arms'>+1</TMPL_IF></td>
-            <td><TMPL_IF enhanceAny eq 'mutate'>+1</TMPL_IF></td>
-            <td><TMPL_IF enhanceAny eq 'modify'>+1</TMPL_IF></td>
+            <td><TMPL_VAR enhanceAnyArms></td>
+            <td><TMPL_VAR enhanceAnyMutate></td>
+            <td><TMPL_VAR enhanceAnyModify></td>
           </tr>
           <tr>
             <th colspan="2">成長</th>


### PR DESCRIPTION
## Summary
- fix Nechronica sheet template causing HTML::Template parse error
- display enhance bonuses via explicit variables
- align age and gender fields horizontally

## Testing
- `perl -c _core/lib/nc/view-chara.pl` *(fails: Can't locate HTML/Template.pm)*

------
https://chatgpt.com/codex/tasks/task_e_684b4474e7b88330a727f844e59b4069