### PR TITLE
Fix NC personal layout

### DIFF
--- a/_core/skin/nc/css/chara.css
+++ b/_core/skin/nc/css/chara.css
@@ -21,12 +21,12 @@ article {
   grid-gap: .5rem;
 }
 #personal {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
   gap: .5rem;
-  flex-wrap: wrap;
 }
 #personal dl {
-  flex: 1;
+  margin: 0;
 }
 
 #maneuvers table,

--- a/_core/skin/nc/css/edit.css
+++ b/_core/skin/nc/css/edit.css
@@ -53,12 +53,12 @@ body:not([data-create-type="F"]) .fullscratch-only {
 #syndrome-status { grid-area: SYN; }
 
 #personal {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
   gap: .5em;
-  flex-wrap: wrap;
 }
 #personal dl {
-  flex: 1;
+  margin: 0;
 }
 
 

--- a/_core/skin/nc/edit-chara.html
+++ b/_core/skin/nc/edit-chara.html
@@ -87,7 +87,6 @@
   <table id="class-enhance" class="edit-table">
     <thead>
       <tr><th colspan="5">ポジション・クラス／強化値</th></tr>
-      <tr><th></th><th></th><th>武装</th><th>変異</th><th>改造</th></tr>
     </thead>
     <tbody>
       <tr>
@@ -103,7 +102,7 @@
         <option>ソロリティ</option>
       </select>
         </td>
-        <td></td><td></td><td></td>
+        <th>武装</th><th>変異</th><th>改造</th>
       </tr>
       <tr>
         <th>メインクラス</th>

--- a/_core/skin/nc/sheet-chara.html
+++ b/_core/skin/nc/sheet-chara.html
@@ -39,13 +39,12 @@
       <table id="class-enhance" class="data-table">
         <thead>
           <tr><th colspan="5">ポジション・クラス／強化値</th></tr>
-          <tr><th></th><th></th><th>武装</th><th>変異</th><th>改造</th></tr>
         </thead>
         <tbody>
           <tr>
             <th>ポジション</th>
             <td><TMPL_VAR position></td>
-            <td></td><td></td><td></td>
+            <th>武装</th><th>変異</th><th>改造</th>
           </tr>
           <tr>
             <th>メインクラス</th>


### PR DESCRIPTION
## Summary
- tweak NC character sheet CSS so age and gender fields display side by side on view and edit pages
- unify edit and view tables for class and enhancement values

## Testing
- `perl -c _core/lib/nc/view-chara.pl` *(fails: HTML::Template module not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bdaed47608330a7a8ec286c2cb81d