### PR TITLE
Enhance NC sheet edit table

### DIFF
--- a/_core/lib/nc/edit-chara.js
+++ b/_core/lib/nc/edit-chara.js
@@ -18,12 +18,12 @@ function calcEnhance(){
   if(mainB){ main=mainB; arms+=mainB.arms; mutate+=mainB.mutate; modify+=mainB.modify; }
   const subB  = classBonus[form.subClass.value];
   if(subB){ sub=subB; arms+=subB.arms; mutate+=subB.mutate; modify+=subB.modify; }
-  document.getElementById('main-class-arms').textContent   = main.arms   || '';
-  document.getElementById('main-class-mutate').textContent = main.mutate || '';
-  document.getElementById('main-class-modify').textContent = main.modify || '';
-  document.getElementById('sub-class-arms').textContent    = sub.arms    || '';
-  document.getElementById('sub-class-mutate').textContent  = sub.mutate  || '';
-  document.getElementById('sub-class-modify').textContent  = sub.modify  || '';
+  document.getElementById('main-class-arms').textContent   = main.arms   ?? '';
+  document.getElementById('main-class-mutate').textContent = main.mutate ?? '';
+  document.getElementById('main-class-modify').textContent = main.modify ?? '';
+  document.getElementById('sub-class-arms').textContent    = sub.arms    ?? '';
+  document.getElementById('sub-class-mutate').textContent  = sub.mutate  ?? '';
+  document.getElementById('sub-class-modify').textContent  = sub.modify  ?? '';
   const any = form.enhanceAny.value;
   if(any==='arms'){ arms++; }
   else if(any==='mutate'){ mutate++; }

--- a/_core/lib/nc/edit-chara.pl
+++ b/_core/lib/nc/edit-chara.pl
@@ -51,6 +51,46 @@ my %any_checked = (
   modify => ($pc{enhanceAny} eq 'modify' ? 'checked' : ''),
 );
 
+my %class_bonus = (
+  'ステーシー'     => { arms => 1, mutate => 1, modify => 0 },
+  'タナトス'      => { arms => 1, mutate => 0, modify => 1 },
+  'ゴシック'      => { arms => 0, mutate => 1, modify => 1 },
+  'レクイエム'    => { arms => 2, mutate => 0, modify => 0 },
+  'バロック'      => { arms => 0, mutate => 2, modify => 0 },
+  'ロマネスク'    => { arms => 0, mutate => 0, modify => 2 },
+  'サイケデリック'=> { arms => 0, mutate => 0, modify => 1 },
+);
+
+my ($arms, $mutate, $modify) = (0,0,0);
+my %main_bonus; my %sub_bonus;
+if(my $b = $class_bonus{$pc{mainClass}}){
+  %main_bonus = %{$b};
+  $arms   += $b->{arms};
+  $mutate += $b->{mutate};
+  $modify += $b->{modify};
+}
+if(my $b = $class_bonus{$pc{subClass}}){
+  %sub_bonus = %{$b};
+  $arms   += $b->{arms};
+  $mutate += $b->{mutate};
+  $modify += $b->{modify};
+}
+$pc{mainClassArms}   = $main_bonus{arms}   || 0;
+$pc{mainClassMutate} = $main_bonus{mutate} || 0;
+$pc{mainClassModify} = $main_bonus{modify} || 0;
+$pc{subClassArms}    = $sub_bonus{arms}    || 0;
+$pc{subClassMutate}  = $sub_bonus{mutate}  || 0;
+$pc{subClassModify}  = $sub_bonus{modify}  || 0;
+if   ($pc{enhanceAny} eq 'arms'  ){ $arms++;   }
+elsif($pc{enhanceAny} eq 'mutate'){ $mutate++; }
+elsif($pc{enhanceAny} eq 'modify'){ $modify++; }
+$pc{enhanceArms}   = $arms;
+$pc{enhanceMutate} = $mutate;
+$pc{enhanceModify} = $modify;
+$pc{enhanceArmsTotal}   = $arms   + $pc{enhanceArmsGrow};
+$pc{enhanceMutateTotal} = $mutate + $pc{enhanceMutateGrow};
+$pc{enhanceModifyTotal} = $modify + $pc{enhanceModifyGrow};
+
 my @groups;
 foreach (@set::groups){
   my ($id, undef, $name, undef, $exclusive) = @$_;
@@ -141,6 +181,15 @@ $tmpl->param(
   enhanceArms  => $pc{enhanceArms},
   enhanceMutate=> $pc{enhanceMutate},
   enhanceModify=> $pc{enhanceModify},
+  mainClassArms     => $pc{mainClassArms},
+  mainClassMutate   => $pc{mainClassMutate},
+  mainClassModify   => $pc{mainClassModify},
+  subClassArms      => $pc{subClassArms},
+  subClassMutate    => $pc{subClassMutate},
+  subClassModify    => $pc{subClassModify},
+  enhanceArmsTotal   => $pc{enhanceArmsTotal},
+  enhanceMutateTotal => $pc{enhanceMutateTotal},
+  enhanceModifyTotal => $pc{enhanceModifyTotal},
   enhanceArmsGrow   => $pc{enhanceArmsGrow},
   enhanceMutateGrow => $pc{enhanceMutateGrow},
   enhanceModifyGrow => $pc{enhanceModifyGrow},

--- a/_core/skin/nc/edit-chara.html
+++ b/_core/skin/nc/edit-chara.html
@@ -118,9 +118,9 @@
         <option value="サイケデリック" <TMPL_VAR mainClassSelected7>>サイケデリック</option>
       </select>
         </td>
-        <td id="main-class-arms"></td>
-        <td id="main-class-mutate"></td>
-        <td id="main-class-modify"></td>
+        <td id="main-class-arms"><TMPL_VAR mainClassArms></td>
+        <td id="main-class-mutate"><TMPL_VAR mainClassMutate></td>
+        <td id="main-class-modify"><TMPL_VAR mainClassModify></td>
       </tr>
       <tr>
         <th>サブクラス</th>
@@ -136,9 +136,9 @@
         <option value="サイケデリック" <TMPL_VAR subClassSelected7>>サイケデリック</option>
       </select>
         </td>
-        <td id="sub-class-arms"></td>
-        <td id="sub-class-mutate"></td>
-        <td id="sub-class-modify"></td>
+        <td id="sub-class-arms"><TMPL_VAR subClassArms></td>
+        <td id="sub-class-mutate"><TMPL_VAR subClassMutate></td>
+        <td id="sub-class-modify"><TMPL_VAR subClassModify></td>
       </tr>
       <tr>
         <th colspan="2">任意選択ボーナス</th>
@@ -154,15 +154,15 @@
       </tr>
       <tr>
         <th colspan="2">合計</th>
-        <td id="enhance-arms-total"></td>
-        <td id="enhance-mutate-total"></td>
-        <td id="enhance-modify-total"></td>
+        <td id="enhance-arms-total"><TMPL_VAR enhanceArmsTotal></td>
+        <td id="enhance-mutate-total"><TMPL_VAR enhanceMutateTotal></td>
+        <td id="enhance-modify-total"><TMPL_VAR enhanceModifyTotal></td>
       </tr>
     </tbody>
   </table>
-  <input type="hidden" name="enhanceArms" id="enhance-arms-base">
-  <input type="hidden" name="enhanceMutate" id="enhance-mutate-base">
-  <input type="hidden" name="enhanceModify" id="enhance-modify-base">
+  <input type="hidden" name="enhanceArms" id="enhance-arms-base" value="<TMPL_VAR enhanceArms>">
+  <input type="hidden" name="enhanceMutate" id="enhance-mutate-base" value="<TMPL_VAR enhanceMutate>">
+  <input type="hidden" name="enhanceModify" id="enhance-modify-base" value="<TMPL_VAR enhanceModify>">
   <dl>
     <dt>行動値<dd><input type="number" name="actionPoint" value="<TMPL_VAR actionPoint>">
     <dt>狂気点<dd><input type="number" name="madnessPoint" value="<TMPL_VAR madnessPoint>">


### PR DESCRIPTION
## Summary
- show class bonus and totals in the Nechronica edit screen
- compute bonus values server-side so defaults display without JS
- keep zero values visible by using nullish checks

## Testing
- `perl -c _core/lib/nc/edit-chara.pl`
- `node -c _core/lib/nc/edit-chara.js`


------
https://chatgpt.com/codex/tasks/task_e_684bdf203e988330b993cc5a176d21cf