### PR TITLE
Fix NC maneuver edit rows

### DIFF
--- a/_core/lib/edit.js
+++ b/_core/lib/edit.js
@@ -1,4 +1,5 @@
 "use strict";
+if(typeof window.gameSystem === 'undefined') window.gameSystem = '';
 const form = document.sheet;
 let sheetType;
 window.addEventListener('load', function(e) {

--- a/_core/lib/nc/edit-chara.js
+++ b/_core/lib/nc/edit-chara.js
@@ -1,6 +1,6 @@
 "use strict";
 const gameSystem = 'nc';
-const form = document.forms.sheet || document.forms[0];
+// NOTE: 'form' is provided by the common edit.js
 const classBonus = {
   'ステーシー':     {arms:1, mutate:1, modify:0},
   'タナトス':      {arms:1, mutate:0, modify:1},
@@ -54,15 +54,17 @@ window.onload = function() {
   ['enhanceArmsGrow','enhanceMutateGrow','enhanceModifyGrow'].forEach(name=>{
     form[name].addEventListener('input',calcEnhance);
   });
-  imagePosition(1);
-  setSortable('maneuver','#maneuver-table tbody','tr');
+  if(typeof imagePosition === 'function'){ imagePosition(1); }
+  if(typeof setSortable === 'function'){
+    setSortable('maneuver','#maneuver-table tbody','tr');
+    setSortable('memory','#memory-table tbody','tr');
+  }
   if(!document.querySelector('#maneuver-list tr')){
-    const num = Number(form.maneuverNum.value) || 0;
+    const num = Math.max(Number(form.maneuverNum.value) || 0, 1);
     for(let i=0; i<num; i++){ addManeuver(); }
   }
-  setSortable('memory','#memory-table tbody','tr');
   if(!document.querySelector('#memory-list tr')){
-    const num = Number(form.memoryNum.value) || 0;
+    const num = Math.max(Number(form.memoryNum.value) || 0, 1);
     for(let i=0; i<num; i++){ addMemory(); }
   }
 };


### PR DESCRIPTION
## Summary
- fix Nechronica edit screen so maneuver rows initialize properly even if JS libs fail
- ensure gameSystem defaults empty if constant not loaded
- avoid duplicate `form` const in NC edit script

## Testing
- `perl -c _core/lib/nc/edit-chara.pl` *(fails: Can't locate HTML::Template.pm)*

------
https://chatgpt.com/codex/tasks/task_e_684bebc7c7188330ba0970b72170ea37