### PR TITLE
Fix NC sheet fields and row deletion

### DIFF
--- a/_core/lib/nc/edit-chara.js
+++ b/_core/lib/nc/edit-chara.js
@@ -74,7 +74,7 @@ function addManeuver(){
   document.querySelector('#maneuver-table tbody').append(createRow('maneuver','maneuverNum'));
 }
 function delManeuver(){
-  delRow('maneuverNum', '#maneuver-table tbody:last-of-type');
+  delRow('maneuverNum', '#maneuver-list tr:last-of-type');
 }
 
 // 記憶のカケラ欄 ----------------------------------------
@@ -82,5 +82,5 @@ function addMemory(){
   document.querySelector('#memory-table tbody').append(createRow('memory','memoryNum',6));
 }
 function delMemory(){
-  delRow('memoryNum', '#memory-table tbody:last-of-type',2);
+  delRow('memoryNum', '#memory-list tr:last-of-type',2);
 }

--- a/_core/lib/nc/edit-chara.pl
+++ b/_core/lib/nc/edit-chara.pl
@@ -196,7 +196,6 @@ $tmpl->param(
   enhanceMutateGrow => $pc{enhanceMutateGrow},
   enhanceModifyGrow => $pc{enhanceModifyGrow},
   actionPoint  => $pc{actionPoint},
-  madnessPoint => $pc{madnessPoint},
   imageURL     => $pc{imageURL},
   imageForm    => $imageForm,
   memoryNum    => $pc{memoryNum},

--- a/_core/skin/nc/edit-chara.html
+++ b/_core/skin/nc/edit-chara.html
@@ -64,10 +64,10 @@
     <dt>タグ<dd><input type="text" name="tags" value="<TMPL_VAR tags>">
   </dl>
 </div>
-<div class="box in-toc" id="name-form" data-content-title="キャラクター名・プレイヤー名">
+<div class="box in-toc" id="name-form" data-content-title="ドール名・プレイヤー名">
   <div>
     <dl id="character-name">
-      <dt>キャラクター名
+      <dt>ドール名
       <dd><input type="text" name="characterName" value="<TMPL_VAR characterName>">
     </dl>
   </div>
@@ -165,7 +165,6 @@
   <input type="hidden" name="enhanceModify" id="enhance-modify-base" value="<TMPL_VAR enhanceModify>">
   <dl>
     <dt>行動値<dd><input type="number" name="actionPoint" value="<TMPL_VAR actionPoint>">
-    <dt>狂気点<dd><input type="number" name="madnessPoint" value="<TMPL_VAR madnessPoint>">
   </dl>
 </section>
 <section id="maneuvers" class="box">

--- a/_core/skin/nc/sheet-chara.html
+++ b/_core/skin/nc/sheet-chara.html
@@ -81,7 +81,6 @@
         </tbody>
       </table>
       <dl><dt>行動値<dd><TMPL_VAR actionPoint></dl>
-      <dl><dt>狂気点<dd><TMPL_VAR madnessPoint></dl>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- update Nechronica sheet labels and remove Madness Point field
- fix maneuver and memory row deletion targeting
- tweak edit page name label

## Testing
- `perl -c _core/lib/nc/edit-chara.pl` *(fails: Can't locate HTML/Template.pm)*
- `node --check _core/lib/nc/edit-chara.js`

------
https://chatgpt.com/codex/tasks/task_e_684bf1dfd020833090c1d0f0f62f545c