### PR TITLE
Fix missing field persistence for NC sheets

### DIFF
--- a/_core/lib/nc/edit-chara.pl
+++ b/_core/lib/nc/edit-chara.pl
@@ -42,10 +42,17 @@ $pc{hide}             ||= 0;
 my @classes = (
   'ステーシー','タナトス','ゴシック','レクイエム','バロック','ロマネスク','サイケデリック'
 );
+my @positions = (
+  'アリス','ホリック','オートマトン','ジャンク','コート','ソロリティ'
+);
 my %main_selected; my %sub_selected;
 foreach my $i (0..$#classes){
   $main_selected{$i+1} = 'selected' if $pc{mainClass} eq $classes[$i];
   $sub_selected{$i+1}  = 'selected' if $pc{subClass}  eq $classes[$i];
+}
+my %position_selected;
+foreach my $i (0..$#positions){
+  $position_selected{$i+1} = 'selected' if $pc{position} eq $positions[$i];
 }
 my %any_checked = (
   arms   => ($pc{enhanceAny} eq 'arms'   ? 'checked' : ''),
@@ -206,6 +213,8 @@ $tmpl->param(
   hide         => $pc{hide},
   group        => $pc{group},
   tags         => $pc{tags},
+  position     => $pc{position},
+  map { ("positionSelected".($_+1) => $position_selected{$_+1}) } 0..$#positions,
   map { ("mainClassSelected".($_+1) => $main_selected{$_+1}) } 0..$#classes,
   map { ("subClassSelected" .($_+1) => $sub_selected{$_+1})  } 0..$#classes,
   enhanceAnyArms   => $any_checked{arms},

--- a/_core/skin/nc/edit-chara.html
+++ b/_core/skin/nc/edit-chara.html
@@ -94,12 +94,12 @@
         <td>
           <select name="position">
         <option value="">--</option>
-        <option>アリス</option>
-        <option>ホリック</option>
-        <option>オートマトン</option>
-        <option>ジャンク</option>
-        <option>コート</option>
-        <option>ソロリティ</option>
+        <option value="アリス" <TMPL_VAR positionSelected1>>アリス</option>
+        <option value="ホリック" <TMPL_VAR positionSelected2>>ホリック</option>
+        <option value="オートマトン" <TMPL_VAR positionSelected3>>オートマトン</option>
+        <option value="ジャンク" <TMPL_VAR positionSelected4>>ジャンク</option>
+        <option value="コート" <TMPL_VAR positionSelected5>>コート</option>
+        <option value="ソロリティ" <TMPL_VAR positionSelected6>>ソロリティ</option>
       </select>
         </td>
         <th>武装</th><th>変異</th><th>改造</th>


### PR DESCRIPTION
## Summary
- ensure position choices retain their selection
- wire up selected state in the NC edit sheet template

## Testing
- `grep -n "positionSelected" -n _core/lib/nc/edit-chara.pl`


------
https://chatgpt.com/codex/tasks/task_e_684c3eef498483309fd9912b34aec14d