### PR TITLE
Fix NC maneuver fields in edit screen

### DIFF
--- a/_core/lib/nc/calc-chara.pl
+++ b/_core/lib/nc/calc-chara.pl
@@ -74,6 +74,13 @@ sub data_calc {
   $pc{enhanceMutateTotal} = $mutate + $pc{enhanceMutateGrow};
   $pc{enhanceModifyTotal} = $modify + $pc{enhanceModifyGrow};
 
+  $pc{freeNote} =~ s/\r\n?|\n/<br>/g;
+
+  if(!$::mode_save){ return %pc; }
+
+  $pc{$_} = pcEscape($pc{$_}) foreach (keys %pc);
+  $pc{tags} = normalizeHashtags($pc{tags});
+
   $::newline = "$pc{id}<>$::file<>$pc{birthTime}<>$::now<>$pc{characterName}<>$pc{playerName}<>$pc{group}<>$pc{lastSession}<>$pc{image}<> $pc{tags} <>$pc{hide}<>";
   return %pc;
 }

--- a/_core/lib/nc/edit-chara.pl
+++ b/_core/lib/nc/edit-chara.pl
@@ -118,16 +118,16 @@ foreach my $i (1 .. $pc{maneuverNum}){
     PART_ARM   => ($pc{"maneuverPart$i"} eq '腕' ? 'selected' : ''),
     PART_BODY  => ($pc{"maneuverPart$i"} eq '胴' ? 'selected' : ''),
     PART_LEG   => ($pc{"maneuverPart$i"} eq '脚' ? 'selected' : ''),
-    NAME   => $pc{"maneuverName$i"},
+    NAME   => pcEscape(pcUnescape($pc{"maneuverName$i"})),
     TIMING_AUTO   => ($pc{"maneuverTiming$i"} eq 'オート'     ? 'selected' : ''),
     TIMING_ACTION => ($pc{"maneuverTiming$i"} eq 'アクション' ? 'selected' : ''),
     TIMING_RAPID  => ($pc{"maneuverTiming$i"} eq 'ラピッド'   ? 'selected' : ''),
     TIMING_JUDGE  => ($pc{"maneuverTiming$i"} eq 'ジャッジ'   ? 'selected' : ''),
     TIMING_DAMAGE => ($pc{"maneuverTiming$i"} eq 'ダメージ'   ? 'selected' : ''),
     TIMING_REF    => ($pc{"maneuverTiming$i"} eq '効果参照'   ? 'selected' : ''),
-    COST   => $pc{"maneuverCost$i"},
-    RANGE  => $pc{"maneuverRange$i"},
-    NOTE   => $pc{"maneuverNote$i"},
+    COST   => pcEscape(pcUnescape($pc{"maneuverCost$i"})),
+    RANGE  => pcEscape(pcUnescape($pc{"maneuverRange$i"})),
+    NOTE   => pcEscape(pcUnescape($pc{"maneuverNote$i"})),
   };
 }
 
@@ -135,8 +135,8 @@ my @memory_rows;
 foreach my $i (1 .. $pc{memoryNum}){
   push @memory_rows, {
     ID   => $i,
-    NAME => $pc{"memoryName$i"},
-    NOTE => $pc{"memoryNote$i"},
+    NAME => pcEscape(pcUnescape($pc{"memoryName$i"})),
+    NOTE => pcEscape(pcUnescape($pc{"memoryNote$i"})),
   };
 }
 
@@ -144,10 +144,10 @@ my @fetter_rows;
 foreach my $i (1 .. 6){
   push @fetter_rows, {
     ID     => $i,
-    TARGET => $pc{"fetterTarget$i"},
-    NOTE   => $pc{"fetterNote$i"},
-    EFFECT => $pc{"fetterEffect$i"},
-    POINT  => $pc{"fetterPoint$i"},
+    TARGET => pcEscape(pcUnescape($pc{"fetterTarget$i"})),
+    NOTE   => pcEscape(pcUnescape($pc{"fetterNote$i"})),
+    EFFECT => pcEscape(pcUnescape($pc{"fetterEffect$i"})),
+    POINT  => pcEscape(pcUnescape($pc{"fetterPoint$i"})),
   };
 }
 
@@ -213,7 +213,7 @@ $tmpl->param(
   memoryNum    => $pc{memoryNum},
   MemoryRows   => \@memory_rows,
   FetterRows   => \@fetter_rows,
-  freeNote     => $pc{freeNote},
+  freeNote     => do { my $t = pcUnescape($pc{freeNote}); $t =~ s/&lt;br&gt;/\n/g; pcEscape($t) },
   forbidden    => $pc{forbidden},
   hide         => $pc{hide},
   group        => $pc{group},

--- a/_core/lib/subroutine.pl
+++ b/_core/lib/subroutine.pl
@@ -438,6 +438,14 @@ sub pcEscape {
   $text =~ tr/\r\n//d;
   return $text;
 }
+sub pcUnescape {
+  my $text = shift;
+  $text =~ s/&amp;/&/g;
+  $text =~ s/&quot;/"/g;
+  $text =~ s/&lt;/</g;
+  $text =~ s/&gt;/>/g;
+  return $text;
+}
 sub normalizeHashtags {
   my $text = shift;
   $text =~ s/\s/ /g; #空白統一


### PR DESCRIPTION
## Summary
- undo HTML escaping for Nechronica maneuver inputs so saved text loads correctly
- add `pcUnescape` helper for reversing `pcEscape`

## Testing
- `perl -c _core/lib/nc/edit-chara.pl` *(fails: Can't locate HTML/Template.pm)*
- `perl -c _core/lib/subroutine.pl` *(fails: Can't locate CGI/Cookie.pm)*

------
https://chatgpt.com/codex/tasks/task_e_684d4a408a1083308bd37041cf80b348