### PR TITLE
Improve maneuver editing functions

### DIFF
--- a/_core/lib/nc/edit-chara.js
+++ b/_core/lib/nc/edit-chara.js
@@ -56,7 +56,6 @@ window.onload = function() {
   });
   if(typeof imagePosition === 'function'){ imagePosition(1); }
   if(typeof setSortable === 'function'){
-    setSortable('maneuver','#maneuver-table tbody','tr');
     setSortable('memory','#memory-table tbody','tr');
   }
   if(!document.querySelector('#maneuver-list tr')){
@@ -76,6 +75,53 @@ function addManeuver(){
 function delManeuver(){
   delRow('maneuverNum', '#maneuver-list tr:last-of-type');
 }
+
+// ソート
+(() => {
+  let sortable = Sortable.create(document.getElementById('maneuver-list'), {
+    group: "maneuver",
+    dataIdAttr: 'id',
+    animation: 150,
+    handle: '.handle',
+    filter: 'thead,tfoot,template',
+    onSort: () => { maneuverSortAfter(); },
+    onStart: () => {
+      document.querySelectorAll('.trash-box').forEach(obj => { obj.style.display = 'none' });
+      document.getElementById('maneuver-trash').style.display = 'block';
+    },
+    onEnd: () => {
+      if(!maneuverTrashNum){ document.getElementById('maneuver-trash').style.display = 'none'; }
+    },
+  });
+
+  let trashtable = Sortable.create(document.getElementById('maneuver-trash-table'), {
+    group: "maneuver",
+    dataIdAttr: 'id',
+    animation: 150,
+    filter: 'thead,tfoot,template',
+  });
+
+  let maneuverTrashNum = 0;
+  function maneuverSortAfter(){
+    let num = 1;
+    for(let id of sortable.toArray()){
+      const row = document.querySelector(`tr#${id}`);
+      if(!row) continue;
+      replaceSortedNames(row,num,/^(maneuver)(?:Trash)?[0-9]+(.+)$/);
+      num++;
+    }
+    form.maneuverNum.value = num-1;
+    let del = 0;
+    for(let id of trashtable.toArray()){
+      const row = document.querySelector(`tr#${id}`);
+      if(!row) continue;
+      del++;
+      replaceSortedNames(row,'Trash'+del,/^(maneuver)(?:Trash)?[0-9]+(.+)$/);
+    }
+    maneuverTrashNum = del;
+    if(!del){ document.getElementById('maneuver-trash').style.display = 'none'; }
+  }
+})();
 
 // 記憶のカケラ欄 ----------------------------------------
 function addMemory(){

--- a/_core/lib/nc/edit-chara.pl
+++ b/_core/lib/nc/edit-chara.pl
@@ -36,7 +36,7 @@ $pc{maneuverNum}      ||= do {
       $max = $num if $num > $max;
     }
   }
-  $max || 3;
+  $max || 5;
 };
 $pc{memoryNum}        ||= 2;
 foreach my $i (1 .. 6){

--- a/_core/skin/nc/edit-chara.html
+++ b/_core/skin/nc/edit-chara.html
@@ -245,6 +245,11 @@
     </tr>
   </template>
 </section>
+<div class="box trash-box" id="maneuver-trash">
+  <h2><span class="material-symbols-outlined">delete</span><span class="shorten">削除マニューバ</span></h2>
+  <table class="edit-table line-tbody" id="maneuver-trash-table"></table>
+  <i class="material-symbols-outlined close-button" onclick="document.getElementById('maneuver-trash').style.display = 'none';">close</i>
+</div>
 <section id="memory" class="box">
   <h2>記憶のカケラ</h2>
   <input type="hidden" name="memoryNum" value="<TMPL_VAR memoryNum>">


### PR DESCRIPTION
## Summary
- preload all maneuver rows from server and default to 5
- support drag sorting with trash box for Nechronica maneuvers

## Testing
- `node -c _core/lib/nc/edit-chara.js`
- `perl -c _core/lib/nc/edit-chara.pl` *(fails: HTML::Template module missing)*

------
https://chatgpt.com/codex/tasks/task_e_684d6814e9e08330a7eb7025b4c71d89