### PR TITLE
Implement server-side maneuver loading

### DIFF
--- a/_core/lib/nc/edit-chara.js
+++ b/_core/lib/nc/edit-chara.js
@@ -58,10 +58,7 @@ window.onload = function() {
   if(typeof setSortable === 'function'){
     setSortable('memory','#memory-table tbody','tr');
   }
-  if(!document.querySelector('#maneuver-list tr')){
-    const num = Math.max(Number(form.maneuverNum.value) || 0, 1);
-    for(let i=0; i<num; i++){ addManeuver(); }
-  }
+  // マニューバは編集画面表示時点でサーバーから出力されるため、既存データ取得の処理は不要
   if(!document.querySelector('#memory-list tr')){
     const num = Math.max(Number(form.memoryNum.value) || 0, 1);
     for(let i=0; i<num; i++){ addMemory(); }


### PR DESCRIPTION
## Summary
- remove JS block that created default maneuver rows on load
- clarify that maneuvers are rendered server-side

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d73a4438883308c788ed8e38f3028