### PR TITLE
Implement server-side maneuver loading

### DIFF
--- a/_core/lib/nc/edit-chara.js
+++ b/_core/lib/nc/edit-chara.js
@@ -58,10 +58,7 @@ window.onload = function() {
   if(typeof setSortable === 'function'){
     setSortable('memory','#memory-table tbody','tr');
   }
-  if(!document.querySelector('#maneuver-list tr')){
-    const num = Math.max(Number(form.maneuverNum.value) || 0, 1);
-    for(let i=0; i<num; i++){ addManeuver(); }
-  }
+  // マニューバは編集画面表示時点でサーバーから出力されるため既存データ取得の処理は不要
   if(!document.querySelector('#memory-list tr')){
     const num = Math.max(Number(form.memoryNum.value) || 0, 1);
     for(let i=0; i<num; i++){ addMemory(); }

--- a/_core/lib/nc/edit-chara.pl
+++ b/_core/lib/nc/edit-chara.pl
@@ -116,28 +116,21 @@ foreach (@set::groups){
   push @groups, { ID=>$id, NAME=>$name, SELECTED=>($pc{group} eq $id ? 1:0) };
 }
 
-my @maneuver_rows;
+my $maneuver_rows_html = '';
 foreach my $i (1 .. $pc{maneuverNum}){
-  push @maneuver_rows, {
-    ID    => $i,
-    BROKEN=> ($pc{"maneuverBroken$i"} ? 'checked' : ''),
-    USED  => ($pc{"maneuverUsed$i"} ? 'checked' : ''),
-    PART_SKILL => ($pc{"maneuverPart$i"} eq 'スキル' ? 'selected' : ''),
-    PART_HEAD  => ($pc{"maneuverPart$i"} eq '頭' ? 'selected' : ''),
-    PART_ARM   => ($pc{"maneuverPart$i"} eq '腕' ? 'selected' : ''),
-    PART_BODY  => ($pc{"maneuverPart$i"} eq '胴' ? 'selected' : ''),
-    PART_LEG   => ($pc{"maneuverPart$i"} eq '脚' ? 'selected' : ''),
-    NAME   => pcEscape(pcUnescape($pc{"maneuverName$i"})),
-    TIMING_AUTO   => ($pc{"maneuverTiming$i"} eq 'オート'     ? 'selected' : ''),
-    TIMING_ACTION => ($pc{"maneuverTiming$i"} eq 'アクション' ? 'selected' : ''),
-    TIMING_RAPID  => ($pc{"maneuverTiming$i"} eq 'ラピッド'   ? 'selected' : ''),
-    TIMING_JUDGE  => ($pc{"maneuverTiming$i"} eq 'ジャッジ'   ? 'selected' : ''),
-    TIMING_DAMAGE => ($pc{"maneuverTiming$i"} eq 'ダメージ'   ? 'selected' : ''),
-    TIMING_REF    => ($pc{"maneuverTiming$i"} eq '効果参照'   ? 'selected' : ''),
-    COST   => pcEscape(pcUnescape($pc{"maneuverCost$i"})),
-    RANGE  => pcEscape(pcUnescape($pc{"maneuverRange$i"})),
-    NOTE   => pcEscape(pcUnescape($pc{"maneuverNote$i"})),
-  };
+  $maneuver_rows_html .= <<"HTML";
+      <tr id="maneuver-row${i}">
+        <td class="handle"></td>
+        <td>@{[ input "maneuver${i}Broken", 'checkbox' ]}</td>
+        <td>@{[ input "maneuver${i}Used",   'checkbox' ]}</td>
+        <td><select name="maneuverPart${i}">@{[ option "maneuverPart${i}",'スキル','頭','腕','胴','脚' ]}</select></td>
+        <td>@{[ input "maneuver${i}Name" ]}</td>
+        <td><select name="maneuverTiming${i}">@{[ option "maneuverTiming${i}",'オート','アクション','ラピッド','ジャッジ','ダメージ','効果参照' ]}</select></td>
+        <td>@{[ input "maneuver${i}Cost" ]}</td>
+        <td>@{[ input "maneuver${i}Range" ]}</td>
+        <td>@{[ input "maneuver${i}Note" ]}</td>
+      </tr>
+HTML
 }
 
 my @memory_rows;
@@ -235,7 +228,7 @@ $tmpl->param(
   enhanceAnyMutate => $any_checked{mutate},
   enhanceAnyModify => $any_checked{modify},
   maneuverNum   => $pc{maneuverNum},
-  ManeuverRows  => \@maneuver_rows,
+  ManeuverRowsHTML => $maneuver_rows_html,
   Groups       => \@groups,
   forbiddenBattle => ($pc{forbidden} eq 'battle' ? 1 : 0),
   forbiddenAll    => ($pc{forbidden} eq 'all'    ? 1 : 0),

--- a/_core/skin/nc/edit-chara.html
+++ b/_core/skin/nc/edit-chara.html
@@ -181,36 +181,7 @@
       <tr><th><th>破損<th>使用<th>部位<th>名称<th>タイミング<th>コスト<th>射程<th class="left">効果</tr>
     </thead>
     <tbody id="maneuver-list">
-<TMPL_LOOP ManeuverRows>
-      <tr id="maneuver-row<TMPL_VAR ID>">
-        <td class="handle"></td>
-        <td><input type="checkbox" name="maneuverBroken<TMPL_VAR ID>" <TMPL_VAR BROKEN>></td>
-        <td><input type="checkbox" name="maneuverUsed<TMPL_VAR ID>" <TMPL_VAR USED>></td>
-        <td>
-          <select name="maneuverPart<TMPL_VAR ID>">
-            <option value="スキル" <TMPL_VAR PART_SKILL>>スキル</option>
-            <option value="頭" <TMPL_VAR PART_HEAD>>頭</option>
-            <option value="腕" <TMPL_VAR PART_ARM>>腕</option>
-            <option value="胴" <TMPL_VAR PART_BODY>>胴</option>
-            <option value="脚" <TMPL_VAR PART_LEG>>脚</option>
-          </select>
-        </td>
-        <td><input type="text" name="maneuverName<TMPL_VAR ID>" value="<TMPL_VAR NAME>"></td>
-        <td>
-          <select name="maneuverTiming<TMPL_VAR ID>">
-            <option value="オート" <TMPL_VAR TIMING_AUTO>>オート</option>
-            <option value="アクション" <TMPL_VAR TIMING_ACTION>>アクション</option>
-            <option value="ラピッド" <TMPL_VAR TIMING_RAPID>>ラピッド</option>
-            <option value="ジャッジ" <TMPL_VAR TIMING_JUDGE>>ジャッジ</option>
-            <option value="ダメージ" <TMPL_VAR TIMING_DAMAGE>>ダメージ</option>
-            <option value="効果参照" <TMPL_VAR TIMING_REF>>効果参照</option>
-          </select>
-        </td>
-        <td><input type="text" name="maneuverCost<TMPL_VAR ID>" value="<TMPL_VAR COST>"></td>
-        <td><input type="text" name="maneuverRange<TMPL_VAR ID>" value="<TMPL_VAR RANGE>"></td>
-        <td><input type="text" name="maneuverNote<TMPL_VAR ID>" value="<TMPL_VAR NOTE>"></td>
-      </tr>
-</TMPL_LOOP>
+<TMPL_VAR ManeuverRowsHTML>
     </tbody>
   </table>
   <div class="add-del-button"><a onclick="addManeuver()">▼</a><a onclick="delManeuver()">▲</a></div>


### PR DESCRIPTION
## Summary
- render existing maneuver rows directly from server-side script
- insert resulting HTML into the maneuver table at load time
- clarify in JS comment that maneuvers are provided server-side

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d73a4438883308c788ed8e38f3028