### PR TITLE
Fix NC maneuver field names

### DIFF
--- a/_core/lib/nc/edit-chara.pl
+++ b/_core/lib/nc/edit-chara.pl
@@ -129,14 +129,14 @@ foreach my $i (1 .. $pc{maneuverNum}){
   $maneuver_rows_html .= <<"HTML";
       <tr id="maneuver-row${i}">
         <td class="handle"></td>
-        <td>@{[ input "maneuver${i}Broken", 'checkbox' ]}</td>
-        <td>@{[ input "maneuver${i}Used",   'checkbox' ]}</td>
+        <td>@{[ input "maneuverBroken${i}", 'checkbox' ]}</td>
+        <td>@{[ input "maneuverUsed${i}",   'checkbox' ]}</td>
         <td><select name="maneuverPart${i}">@{[ option "maneuverPart${i}",'スキル','頭','腕','胴','脚' ]}</select></td>
-        <td>@{[ input "maneuver${i}Name" ]}</td>
+        <td>@{[ input "maneuverName${i}" ]}</td>
         <td><select name="maneuverTiming${i}">@{[ option "maneuverTiming${i}",'オート','アクション','ラピッド','ジャッジ','ダメージ','効果参照' ]}</select></td>
-        <td>@{[ input "maneuver${i}Cost" ]}</td>
-        <td>@{[ input "maneuver${i}Range" ]}</td>
-        <td>@{[ input "maneuver${i}Note" ]}</td>
+        <td>@{[ input "maneuverCost${i}" ]}</td>
+        <td>@{[ input "maneuverRange${i}" ]}</td>
+        <td>@{[ input "maneuverNote${i}" ]}</td>
       </tr>
 HTML
 }


### PR DESCRIPTION
## Summary
- correct maneuver field names in edit-chara.pl

## Testing
- `perl -c _core/lib/nc/edit-chara.pl` *(fails: "input" not declared)*

------
https://chatgpt.com/codex/tasks/task_e_684d7d681d508330aa0e4620fa920a1d