### PR TITLE
Fix NC option select rendering

### DIFF
--- a/_core/lib/nc/edit-chara.pl
+++ b/_core/lib/nc/edit-chara.pl
@@ -131,9 +131,9 @@ foreach my $i (1 .. $pc{maneuverNum}){
         <td class="handle"></td>
         <td>@{[ input "maneuverBroken${i}", 'checkbox' ]}</td>
         <td>@{[ input "maneuverUsed${i}",   'checkbox' ]}</td>
-        <td><select name="maneuverPart${i}">@{[ option "maneuverPart${i}",'スキル','頭','腕','胴','脚' ]}</select></td>
+        <td><select name="maneuverPart${i}">@{[ optionNc "maneuverPart${i}",'スキル','頭','腕','胴','脚' ]}</select></td>
         <td>@{[ input "maneuverName${i}" ]}</td>
-        <td><select name="maneuverTiming${i}">@{[ option "maneuverTiming${i}",'オート','アクション','ラピッド','ジャッジ','ダメージ','効果参照' ]}</select></td>
+        <td><select name="maneuverTiming${i}">@{[ optionNc "maneuverTiming${i}",'オート','アクション','ラピッド','ジャッジ','ダメージ','効果参照' ]}</select></td>
         <td>@{[ input "maneuverCost${i}" ]}</td>
         <td>@{[ input "maneuverRange${i}" ]}</td>
         <td>@{[ input "maneuverNote${i}" ]}</td>

--- a/_core/lib/nc/subroutine-nc.pl
+++ b/_core/lib/nc/subroutine-nc.pl
@@ -1,6 +1,29 @@
 use strict;
 use utf8;
 
-# Placeholder for Nechronica specific routines
+# Nechronica 専用サブルーチン
+
+### select要素生成 --------------------------------------------------
+#   optionNc('name', @list)
+#   @list: 'value|<label>' ...
+sub optionNc {
+  my $name = shift;
+  my $text = '<option value=""></option>';
+  foreach my $i (@_) {
+    my $value = $i;
+    my $view;
+    if($value =~ s/^label=//){
+      $text .= '<optgroup label="'.$value.'">';
+      next;
+    }
+    elsif($value eq 'close_group') {
+      $text .= '</optgroup>';
+      next;
+    }
+    if($value =~ s/\|\<(.*?)\>$//){ $view = $1 } else { $view = $value }
+    $text .= '<option value="'.$value.'"'.($::pc{$name} eq $value ? ' selected':'').'>'.$view.'</option>';
+  }
+  return $text;
+}
 
 1;


### PR DESCRIPTION
## Summary
- add `optionNc` helper for Nechronica-specific selects
- apply `optionNc` when rendering maneuver rows

## Testing
- `perl -c _core/lib/nc/subroutine-nc.pl`
- *(failed to run `perl -c _core/lib/nc/edit-chara.pl` due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684d86b8b3f48330bb5897f91e4c5c90