### PR TITLE
Fix line breaks in Nechronica insanity notes

### DIFF
--- a/_core/lib/nc/calc-chara.pl
+++ b/_core/lib/nc/calc-chara.pl
@@ -85,6 +85,9 @@ sub data_calc {
   $pc{enhanceModifyTotal} = $modify + $pc{enhanceModifyGrow};
 
   $pc{freeNote} =~ s/\r\n?|\n/<br>/g;
+  foreach my $i (1 .. 6){
+    $pc{"fetterEffectNote$i"} =~ s/\r\n?|\n/<br>/g;
+  }
 
   if(!$::mode_save){ return %pc; }
 

--- a/_core/lib/nc/edit-chara.pl
+++ b/_core/lib/nc/edit-chara.pl
@@ -157,7 +157,7 @@ foreach my $i (1 .. 6){
     TARGET => pcEscape(pcUnescape($pc{"fetterTarget$i"})),
     NOTE   => pcEscape(pcUnescape($pc{"fetterNote$i"})),
     EFFECT => pcEscape(pcUnescape($pc{"fetterEffect$i"})),
-    EFFECT_NOTE => pcEscape(pcUnescape($pc{"fetterEffectNote$i"})),
+    EFFECT_NOTE => do { my $t = pcUnescape($pc{"fetterEffectNote$i"}); $t =~ s/&lt;br&gt;/\n/g; pcEscape($t) },
     POINT  => pcEscape(pcUnescape($pc{"fetterPoint$i"})),
   };
 }

--- a/_core/lib/nc/view-chara.pl
+++ b/_core/lib/nc/view-chara.pl
@@ -8,6 +8,10 @@ my $LOGIN_ID = $::LOGIN_ID;
 
 our %pc = getSheetData();
 
+foreach my $i (1 .. 6){
+  $pc{"fetterEffectNote$i"} = unescapeTags($pc{"fetterEffectNote$i"});
+}
+
 # 任意選択ボーナスの表示用
 my %enhance_any_mark = (
   arms   => ($pc{enhanceAny} eq 'arms'   ? '+1' : ''),


### PR DESCRIPTION
## Summary
- handle newline conversion for Nechronica sheet
- keep insanity note line breaks when editing and viewing

## Testing
- `perl -c _core/lib/nc/calc-chara.pl`
- `perl -c _core/lib/nc/edit-chara.pl` *(fails: Can't locate HTML/Template.pm)*

------
https://chatgpt.com/codex/tasks/task_e_684d90ef90448330b309ea9a11e5174d