### PR TITLE
Replace maneuvers with DX3-style effects in nc sheets

### DIFF
--- a/_core/lib/nc/calc-chara.pl
+++ b/_core/lib/nc/calc-chara.pl
@@ -10,12 +10,29 @@ sub data_calc {
   $pc{tags} ||= '';
   $pc{hide} ||= 0;
 
+  $pc{effectNum} ||= 6;
+
   ### 記憶のカケラ
   $pc{memoryNum} ||= 2;
   $pc{memoryNum} = 6 if $pc{memoryNum} > 6;
   foreach my $i (1 .. $pc{memoryNum}){
     $pc{"memoryName$i"} ||= '';
     $pc{"memoryNote$i"} ||= '';
+  }
+
+  foreach my $i (1 .. $pc{effectNum}){
+    $pc{"effectName$i"}     ||= '';
+    $pc{"effectLv$i"}       ||= '';
+    $pc{"effectTiming$i"}   ||= '';
+    $pc{"effectSkill$i"}    ||= '';
+    $pc{"effectDfclty$i"}   ||= '';
+    $pc{"effectTarget$i"}   ||= '';
+    $pc{"effectRange$i"}    ||= '';
+    $pc{"effectEncroach$i"} ||= '';
+    $pc{"effectRestrict$i"} ||= '';
+    $pc{"effectType$i"}     ||= '';
+    $pc{"effectExp$i"}      ||= '';
+    $pc{"effectNote$i"}     ||= '';
   }
 
   ### 未練／狂気

--- a/_core/lib/nc/edit-chara.js
+++ b/_core/lib/nc/edit-chara.js
@@ -97,58 +97,59 @@ window.onload = function() {
   }
 };
 
-// マニューバ欄 ----------------------------------------
-function addManeuver(){
-  document.querySelector('#maneuver-table tbody').append(createRow('maneuver','maneuverNum'));
+// エフェクト欄 ----------------------------------------
+function addEffect(){
+  document.querySelector('#effect-table').append(createRow('effect','effectNum'));
 }
-function delManeuver(){
-  delRow('maneuverNum', '#maneuver-list tr:last-of-type');
+function delEffect(){
+  if(delRow('effectNum', '#effect-table tbody:last-of-type')){
+    // 追加の計算処理があればここに
+  }
 }
 
-// ソート
 (() => {
-  let sortable = Sortable.create(document.getElementById('maneuver-list'), {
-    group: "maneuver",
+  let sortable = Sortable.create(document.getElementById('effect-table'), {
+    group: 'effect',
     dataIdAttr: 'id',
     animation: 150,
     handle: '.handle',
     filter: 'thead,tfoot,template',
-    onSort: () => { maneuverSortAfter(); },
+    onSort: () => { effectSortAfter(); },
     onStart: () => {
       document.querySelectorAll('.trash-box').forEach(obj => { obj.style.display = 'none' });
-      document.getElementById('maneuver-trash').style.display = 'block';
+      document.getElementById('effect-trash').style.display = 'block';
     },
     onEnd: () => {
-      if(!maneuverTrashNum){ document.getElementById('maneuver-trash').style.display = 'none'; }
+      if(!effectTrashNum){ document.getElementById('effect-trash').style.display = 'none'; }
     },
   });
 
-  let trashtable = Sortable.create(document.getElementById('maneuver-trash-table'), {
-    group: "maneuver",
+  let trashtable = Sortable.create(document.getElementById('effect-trash-table'), {
+    group: 'effect',
     dataIdAttr: 'id',
     animation: 150,
     filter: 'thead,tfoot,template',
   });
 
-  let maneuverTrashNum = 0;
-  function maneuverSortAfter(){
+  let effectTrashNum = 0;
+  function effectSortAfter(){
     let num = 1;
     for(let id of sortable.toArray()){
-      const row = document.querySelector(`tr#${id}`);
+      const row = document.querySelector(`tbody#${id}`);
       if(!row) continue;
-      replaceSortedNames(row,num,/^(maneuver)(?:Trash)?[0-9]+(.+)$/);
+      replaceSortedNames(row,num,/^(effect)(?:Trash)?[0-9]+(.+)$/);
       num++;
     }
-    form.maneuverNum.value = num-1;
+    form.effectNum.value = num-1;
     let del = 0;
     for(let id of trashtable.toArray()){
-      const row = document.querySelector(`tr#${id}`);
+      const row = document.querySelector(`tbody#${id}`);
       if(!row) continue;
       del++;
-      replaceSortedNames(row,'Trash'+del,/^(maneuver)(?:Trash)?[0-9]+(.+)$/);
+      replaceSortedNames(row,'Trash'+del,/^(effect)(?:Trash)?[0-9]+(.+)$/);
     }
-    maneuverTrashNum = del;
-    if(!del){ document.getElementById('maneuver-trash').style.display = 'none'; }
+    effectTrashNum = del;
+    if(!del){ document.getElementById('effect-trash').style.display = 'none'; }
   }
 })();
 

--- a/_core/lib/nc/edit-chara.pl
+++ b/_core/lib/nc/edit-chara.pl
@@ -28,10 +28,10 @@ $pc{enhanceArmsGrow}   ||= 0;
 $pc{enhanceMutateGrow} ||= 0;
 $pc{enhanceModifyGrow} ||= 0;
 $pc{enhanceAny}       ||= '';
-$pc{maneuverNum}      ||= do {
+$pc{effectNum}      ||= do {
   my $max = 0;
   foreach my $key (keys %pc){
-    if($key =~ /^maneuverName(\d+)$/){
+    if($key =~ /^effectName(\d+)$/){
       my $num = $1;
       $max = $num if $num > $max;
     }
@@ -124,21 +124,26 @@ foreach (@set::groups){
   push @groups, { ID=>$id, NAME=>$name, SELECTED=>($pc{group} eq $id ? 1:0) };
 }
 
-my $maneuver_rows_html = '';
-foreach my $i (1 .. $pc{maneuverNum}){
-  $maneuver_rows_html .= <<"HTML";
-      <tr id="maneuver-row${i}">
-        <td class="handle"></td>
-        <td>@{[ input "maneuverBroken${i}", 'checkbox' ]}</td>
-        <td>@{[ input "maneuverUsed${i}",   'checkbox' ]}</td>
-        <td><select name="maneuverPart${i}">@{[ optionNc "maneuverPart${i}",'スキル','頭','腕','胴','脚' ]}</select></td>
-        <td>@{[ input "maneuverName${i}" ]}</td>
-        <td><select name="maneuverTiming${i}">@{[ optionNc "maneuverTiming${i}",'オート','アクション','ラピッド','ジャッジ','ダメージ','効果参照' ]}</select></td>
-        <td>@{[ input "maneuverCost${i}" ]}</td>
-        <td>@{[ input "maneuverRange${i}" ]}</td>
-        <td>@{[ input "maneuverNote${i}" ]}</td>
-      </tr>
-HTML
+my @effect_rows;
+foreach my $i (1 .. $pc{effectNum}){
+  push @effect_rows, {
+    ID       => $i,
+    NAME     => pcEscape(pcUnescape($pc{"effectName$i"})),
+    LV       => $pc{"effectLv$i"},
+    TIMING   => pcEscape(pcUnescape($pc{"effectTiming$i"})),
+    SKILL    => pcEscape(pcUnescape($pc{"effectSkill$i"})),
+    DFCLTY   => pcEscape(pcUnescape($pc{"effectDfclty$i"})),
+    TARGET   => pcEscape(pcUnescape($pc{"effectTarget$i"})),
+    RANGE    => pcEscape(pcUnescape($pc{"effectRange$i"})),
+    ENCROACH => pcEscape(pcUnescape($pc{"effectEncroach$i"})),
+    RESTRICT => pcEscape(pcUnescape($pc{"effectRestrict$i"})),
+    TYPE_AUTO  => ($pc{"effectType$i"} eq 'auto'  ? 1 : 0),
+    TYPE_DLOIS => ($pc{"effectType$i"} eq 'dlois' ? 1 : 0),
+    TYPE_EASY  => ($pc{"effectType$i"} eq 'easy'  ? 1 : 0),
+    TYPE_ENEMY => ($pc{"effectType$i"} eq 'enemy' ? 1 : 0),
+    EXP      => $pc{"effectExp$i"},
+    NOTE     => pcEscape(pcUnescape($pc{"effectNote$i"})),
+  };
 }
 
 my @memory_rows;
@@ -236,8 +241,8 @@ $tmpl->param(
   enhanceAnyArms   => $any_checked{arms},
   enhanceAnyMutate => $any_checked{mutate},
   enhanceAnyModify => $any_checked{modify},
-  maneuverNum   => $pc{maneuverNum},
-  ManeuverRowsHTML => $maneuver_rows_html,
+  effectNum    => $pc{effectNum},
+  EffectRows   => \@effect_rows,
   Groups       => \@groups,
   forbiddenBattle => ($pc{forbidden} eq 'battle' ? 1 : 0),
   forbiddenAll    => ($pc{forbidden} eq 'all'    ? 1 : 0),

--- a/_core/lib/nc/view-chara.pl
+++ b/_core/lib/nc/view-chara.pl
@@ -31,18 +31,22 @@ my $tmpl = HTML::Template->new(
   global_vars       => 1,
 );
 
-$pc{maneuverNum} ||= 3;
-my @maneuvers;
-foreach my $i (1 .. $pc{maneuverNum}){
-  push @maneuvers, {
-    BROKEN => ($pc{"maneuverBroken$i"} ? '☑' : ''),
-    USED   => ($pc{"maneuverUsed$i"}  ? '☑' : ''),
-    PART   => $pc{"maneuverPart$i"},
-    NAME   => $pc{"maneuverName$i"},
-    TIMING => $pc{"maneuverTiming$i"},
-    COST   => $pc{"maneuverCost$i"},
-    RANGE  => $pc{"maneuverRange$i"},
-    NOTE   => $pc{"maneuverNote$i"},
+$pc{effectNum} ||= 0;
+my @effects;
+foreach my $i (1 .. $pc{effectNum}){
+  push @effects, {
+    TYPE     => $pc{"effectType$i"},
+    NAME     => $pc{"effectName$i"},
+    LV       => $pc{"effectLv$i"},
+    TIMING   => $pc{"effectTiming$i"},
+    SKILL    => $pc{"effectSkill$i"},
+    DFCLTY   => $pc{"effectDfclty$i"},
+    TARGET   => $pc{"effectTarget$i"},
+    RANGE    => $pc{"effectRange$i"},
+    ENCROACH => $pc{"effectEncroach$i"},
+    RESTRICT => $pc{"effectRestrict$i"},
+    NOTE     => $pc{"effectNote$i"},
+    EXP      => $pc{"effectExp$i"},
   };
 }
 
@@ -88,7 +92,7 @@ $tmpl->param(
   %pc,
   groupName   => $group_name,
   Tags        => \@tags,
-  Maneuvers   => \@maneuvers,
+  Effects     => \@effects,
   MemoryRows  => \@memory_rows,
   FetterRows  => \@fetter_rows,
   enhanceAnyArms   => $enhance_any_mark{arms},

--- a/_core/skin/nc/css/chara.css
+++ b/_core/skin/nc/css/chara.css
@@ -33,15 +33,51 @@ article {
   margin: 0;
 }
 
-#maneuvers table,
+
+#effect table,
 #enhancement table {
   width: 100%;
   border-collapse: collapse;
 }
 
-#maneuvers th, #maneuvers td {
+#effect table th,
+#effect table td {
   border: 1px solid #aaa;
   padding: .2rem .4rem;
+}
+
+#effect table thead th:nth-child(n+4) {
+  font-size: 90%;
+}
+
+#effect table tbody td:nth-child(n+2) {
+  font-family: var(--font-proportional);
+  font-feature-settings: "palt";
+}
+
+#effect table tbody td:nth-child(2) { font-weight: bold; }
+#effect table tbody td:nth-child(4),
+#effect table tbody td:nth-child(5),
+#effect table tbody td:nth-child(6),
+#effect table tbody td:nth-child(7),
+#effect table tbody td:nth-child(8),
+#effect table tbody td:nth-child(10) {
+  font-size: 90%;
+}
+
+#effect table tbody td.note {
+  padding-left: .5rem;
+  display: none;
+}
+
+#effect[data-full-open="true"] table tbody td.note,
+#effect table tbody:hover td.note {
+  display: table-cell;
+}
+
+#effect table tbody td.note span.right {
+  float: right;
+  font-size: 90%;
 }
 
 #free-note {

--- a/_core/skin/nc/edit-chara.html
+++ b/_core/skin/nc/edit-chara.html
@@ -173,53 +173,82 @@
     <TMPL_VAR imageForm>
   </div>
 </section>
-<section id="maneuvers" class="box">
-  <h2>マニューバ</h2>
-  <input type="hidden" name="maneuverNum" value="<TMPL_VAR maneuverNum>">
-  <table class="edit-table line-tbody no-border-cells" id="maneuver-table">
-    <thead>
-      <tr><th><th>破損<th>使用<th>部位<th>名称<th>タイミング<th>コスト<th>射程<th class="left">効果</tr>
+<section id="effect" class="box">
+  <h2>エフェクト</h2>
+  <input type="hidden" name="effectNum" value="<TMPL_VAR effectNum>">
+  <table class="edit-table line-tbody no-border-cells" id="effect-table">
+    <thead id="effect-head">
+      <tr><th><th>名称<th>LV<th>タイミング<th>技能<th>難易度<th>対象<th>射程<th>侵蝕値<th>制限</tr>
     </thead>
-    <tbody id="maneuver-list">
-<TMPL_VAR ManeuverRowsHTML>
+<TMPL_LOOP EffectRows>
+    <tbody id="effect-row<TMPL_VAR ID>">
+      <tr>
+        <td rowspan="2" class="handle"></td>
+        <td><input type="text" name="effect<TMPL_VAR ID>Name" value="<TMPL_VAR NAME>" placeholder="名称"></td>
+        <td><input type="number" name="effect<TMPL_VAR ID>Lv" value="<TMPL_VAR LV>" min="0" placeholder="Lv"></td>
+        <td><input type="text" name="effect<TMPL_VAR ID>Timing" value="<TMPL_VAR TIMING>" placeholder="タイミング"></td>
+        <td><input type="text" name="effect<TMPL_VAR ID>Skill" value="<TMPL_VAR SKILL>" placeholder="技能"></td>
+        <td><input type="text" name="effect<TMPL_VAR ID>Dfclty" value="<TMPL_VAR DFCLTY>" placeholder="難易度"></td>
+        <td><input type="text" name="effect<TMPL_VAR ID>Target" value="<TMPL_VAR TARGET>" placeholder="対象"></td>
+        <td><input type="text" name="effect<TMPL_VAR ID>Range" value="<TMPL_VAR RANGE>" placeholder="射程"></td>
+        <td><input type="text" name="effect<TMPL_VAR ID>Encroach" value="<TMPL_VAR ENCROACH>" placeholder="侵蝕値"></td>
+        <td><input type="text" name="effect<TMPL_VAR ID>Restrict" value="<TMPL_VAR RESTRICT>" placeholder="制限"></td>
+      </tr>
+      <tr>
+        <td colspan="9">
+          <div>
+            <b>種別</b><select name="effect<TMPL_VAR ID>Type">
+              <option value="">--</option>
+              <option value="auto"  <TMPL_IF TYPE_AUTO>selected</TMPL_IF>>自動</option>
+              <option value="dlois" <TMPL_IF TYPE_DLOIS>selected</TMPL_IF>>Dロイス</option>
+              <option value="easy"  <TMPL_IF TYPE_EASY>selected</TMPL_IF>>イージー</option>
+              <option value="enemy" <TMPL_IF TYPE_ENEMY>selected</TMPL_IF>>エネミー</option>
+            </select>
+            <b class="small">経験点修正</b><input type="number" name="effect<TMPL_VAR ID>Exp" value="<TMPL_VAR EXP>">
+            <b>効果</b><input type="text" name="effect<TMPL_VAR ID>Note" value="<TMPL_VAR NOTE>">
+          </div>
+        </td>
+      </tr>
     </tbody>
+</TMPL_LOOP>
   </table>
-  <div class="add-del-button"><a onclick="addManeuver()">▼</a><a onclick="delManeuver()">▲</a></div>
-  <template id="maneuver-template">
-    <tr id="maneuver-rowTMPL">
-      <td class="handle"></td>
-      <td><input type="checkbox" name="maneuverBrokenTMPL"></td>
-      <td><input type="checkbox" name="maneuverUsedTMPL"></td>
-      <td>
-        <select name="maneuverPartTMPL">
-          <option value="スキル">スキル</option>
-          <option value="頭">頭</option>
-          <option value="腕">腕</option>
-          <option value="胴">胴</option>
-          <option value="脚">脚</option>
-        </select>
-      </td>
-      <td><input type="text" name="maneuverNameTMPL"></td>
-      <td>
-        <select name="maneuverTimingTMPL">
-          <option value="オート">オート</option>
-          <option value="アクション">アクション</option>
-          <option value="ラピッド">ラピッド</option>
-          <option value="ジャッジ">ジャッジ</option>
-          <option value="ダメージ">ダメージ</option>
-          <option value="効果参照">効果参照</option>
-        </select>
-      </td>
-      <td><input type="text" name="maneuverCostTMPL"></td>
-      <td><input type="text" name="maneuverRangeTMPL"></td>
-      <td><input type="text" name="maneuverNoteTMPL"></td>
-    </tr>
+  <div class="add-del-button"><a onclick="addEffect()">▼</a><a onclick="delEffect()">▲</a></div>
+  <template id="effect-template">
+    <tbody id="effect-rowTMPL">
+      <tr>
+        <td rowspan="2" class="handle"></td>
+        <td><input type="text" name="effectNameTMPL" placeholder="名称"></td>
+        <td><input type="number" name="effectLvTMPL" min="0" placeholder="Lv"></td>
+        <td><input type="text" name="effectTimingTMPL" placeholder="タイミング"></td>
+        <td><input type="text" name="effectSkillTMPL" placeholder="技能"></td>
+        <td><input type="text" name="effectDfcltyTMPL" placeholder="難易度"></td>
+        <td><input type="text" name="effectTargetTMPL" placeholder="対象"></td>
+        <td><input type="text" name="effectRangeTMPL" placeholder="射程"></td>
+        <td><input type="text" name="effectEncroachTMPL" placeholder="侵蝕値"></td>
+        <td><input type="text" name="effectRestrictTMPL" placeholder="制限"></td>
+      </tr>
+      <tr>
+        <td colspan="9">
+          <div>
+            <b>種別</b><select name="effectTypeTMPL">
+              <option value="">--</option>
+              <option value="auto">自動</option>
+              <option value="dlois">Dロイス</option>
+              <option value="easy">イージー</option>
+              <option value="enemy">エネミー</option>
+            </select>
+            <b class="small">経験点修正</b><input type="number" name="effectExpTMPL">
+            <b>効果</b><input type="text" name="effectNoteTMPL">
+          </div>
+        </td>
+      </tr>
+    </tbody>
   </template>
 </section>
-<div class="box trash-box" id="maneuver-trash">
-  <h2><span class="material-symbols-outlined">delete</span><span class="shorten">削除マニューバ</span></h2>
-  <table class="edit-table line-tbody" id="maneuver-trash-table"></table>
-  <i class="material-symbols-outlined close-button" onclick="document.getElementById('maneuver-trash').style.display = 'none';">close</i>
+<div class="box trash-box" id="effect-trash">
+  <h2><span class="material-symbols-outlined">delete</span><span class="shorten">削除エフェクト</span></h2>
+  <table class="edit-table line-tbody" id="effect-trash-table"></table>
+  <i class="material-symbols-outlined close-button" onclick="document.getElementById('effect-trash').style.display = 'none';">close</i>
 </div>
 <section id="memory" class="box">
   <h2>記憶のカケラ</h2>

--- a/_core/skin/nc/sheet-chara.html
+++ b/_core/skin/nc/sheet-chara.html
@@ -90,28 +90,40 @@
     </div>
   </div>
 
-  <section id="maneuvers" class="box">
-    <h2>マニューバ</h2>
-    <table>
+  <section class="box effects" id="effect">
+    <h2>エフェクト</h2>
+    <button class="open-button" onclick="switchEffectNoteFullOpen();" data-open="" data-text-open="効果を全展開" data-text-close="効果を折畳む"></button>
+    <table class="data-table line-tbody">
       <thead>
-        <tr><th>破損<th>使用<th>部位<th>名称<th>タイミング<th>コスト<th>射程<th>効果</tr>
+        <tr><th>種別<th>名称<th>LV<th>タイミング<th>技能<th>難易度<th>対象<th>射程<th>侵蝕値<th>制限</tr>
       </thead>
-      <tbody>
-        <TMPL_LOOP Maneuvers>
-        <tr>
-          <td><TMPL_VAR BROKEN></td>
-          <td><TMPL_VAR USED></td>
-          <td><TMPL_VAR PART></td>
-          <td><TMPL_VAR NAME></td>
+      <TMPL_LOOP Effects><tbody>
+         <tr>
+          <td rowspan="2"><TMPL_IF TYPE><i class="ef-<TMPL_VAR TYPE>"></i></TMPL_IF></td>
+          <td class="name"><TMPL_VAR NAME></td>
+          <td><TMPL_VAR LV></td>
           <td><TMPL_VAR TIMING></td>
-          <td><TMPL_VAR COST></td>
+          <td><TMPL_VAR SKILL></td>
+          <td><TMPL_VAR DFCLTY></td>
+          <td><TMPL_VAR TARGET></td>
           <td><TMPL_VAR RANGE></td>
-          <td><TMPL_VAR NOTE></td>
+          <td><TMPL_VAR ENCROACH></td>
+          <td><TMPL_VAR RESTRICT></td>
         </tr>
-        </TMPL_LOOP>
-      </tbody>
+        <tr>
+          <td class="note" colspan="9"><TMPL_VAR NOTE><TMPL_IF EXP><span class="right">［<b>経験点修正</b>:<TMPL_VAR EXP>点］</span></TMPL_IF></td>
+        </tr>
+      </TMPL_LOOP>
     </table>
   </section>
+  <script>
+    let effectFullOpen = false;
+    function switchEffectNoteFullOpen(){
+      effectFullOpen = !effectFullOpen;
+      document.getElementById('effect').dataset.fullOpen = effectFullOpen ? 'true' : '';
+      document.querySelector('#effect .open-button').dataset.open = effectFullOpen ? 'true' : '';
+    }
+  </script>
 
   <section id="memory" class="box">
     <h2>記憶のカケラ</h2>


### PR DESCRIPTION
## Summary
- remove Nechronica maneuver tables
- add DX3 style effect sections to edit and view
- update styles and JS helpers

## Testing
- `perl -c _core/lib/nc/edit-chara.pl` *(fails: HTML::Template missing)*
- `perl -c _core/lib/nc/view-chara.pl` *(fails: HTML::Template missing)*
- `perl -c _core/lib/nc/calc-chara.pl`

------
https://chatgpt.com/codex/tasks/task_e_684d92c7efa88330bf30bb1545f2b38e