### PR TITLE
Implement datalist helpers for NC effects

### DIFF
--- a/_core/lib/nc/calc-chara.pl
+++ b/_core/lib/nc/calc-chara.pl
@@ -10,12 +10,23 @@ sub data_calc {
   $pc{tags} ||= '';
   $pc{hide} ||= 0;
 
+  $pc{effectNum} ||= 6;
+
   ### 記憶のカケラ
   $pc{memoryNum} ||= 2;
   $pc{memoryNum} = 6 if $pc{memoryNum} > 6;
   foreach my $i (1 .. $pc{memoryNum}){
     $pc{"memoryName$i"} ||= '';
     $pc{"memoryNote$i"} ||= '';
+  }
+
+  foreach my $i (1 .. $pc{effectNum}){
+    $pc{"effectPart$i"}   ||= '';
+    $pc{"effectName$i"}   ||= '';
+    $pc{"effectTiming$i"} ||= '';
+    $pc{"effectCost$i"}   ||= '';
+    $pc{"effectRange$i"}  ||= '';
+    $pc{"effectNote$i"}   ||= '';
   }
 
   ### 未練／狂気

--- a/_core/lib/nc/edit-chara.js
+++ b/_core/lib/nc/edit-chara.js
@@ -97,58 +97,59 @@ window.onload = function() {
   }
 };
 
-// マニューバ欄 ----------------------------------------
-function addManeuver(){
-  document.querySelector('#maneuver-table tbody').append(createRow('maneuver','maneuverNum'));
+// エフェクト欄 ----------------------------------------
+function addEffect(){
+  document.querySelector('#effect-table').append(createRow('effect','effectNum'));
 }
-function delManeuver(){
-  delRow('maneuverNum', '#maneuver-list tr:last-of-type');
+function delEffect(){
+  if(delRow('effectNum', '#effect-table tbody:last-of-type')){
+    // 追加の計算処理があればここに
+  }
 }
 
-// ソート
 (() => {
-  let sortable = Sortable.create(document.getElementById('maneuver-list'), {
-    group: "maneuver",
+  let sortable = Sortable.create(document.getElementById('effect-table'), {
+    group: 'effect',
     dataIdAttr: 'id',
     animation: 150,
     handle: '.handle',
     filter: 'thead,tfoot,template',
-    onSort: () => { maneuverSortAfter(); },
+    onSort: () => { effectSortAfter(); },
     onStart: () => {
       document.querySelectorAll('.trash-box').forEach(obj => { obj.style.display = 'none' });
-      document.getElementById('maneuver-trash').style.display = 'block';
+      document.getElementById('effect-trash').style.display = 'block';
     },
     onEnd: () => {
-      if(!maneuverTrashNum){ document.getElementById('maneuver-trash').style.display = 'none'; }
+      if(!effectTrashNum){ document.getElementById('effect-trash').style.display = 'none'; }
     },
   });
 
-  let trashtable = Sortable.create(document.getElementById('maneuver-trash-table'), {
-    group: "maneuver",
+  let trashtable = Sortable.create(document.getElementById('effect-trash-table'), {
+    group: 'effect',
     dataIdAttr: 'id',
     animation: 150,
     filter: 'thead,tfoot,template',
   });
 
-  let maneuverTrashNum = 0;
-  function maneuverSortAfter(){
+  let effectTrashNum = 0;
+  function effectSortAfter(){
     let num = 1;
     for(let id of sortable.toArray()){
-      const row = document.querySelector(`tr#${id}`);
+      const row = document.querySelector(`tbody#${id}`);
       if(!row) continue;
-      replaceSortedNames(row,num,/^(maneuver)(?:Trash)?[0-9]+(.+)$/);
+      replaceSortedNames(row,num,/^(effect)(?:Trash)?[0-9]+(.+)$/);
       num++;
     }
-    form.maneuverNum.value = num-1;
+    form.effectNum.value = num-1;
     let del = 0;
     for(let id of trashtable.toArray()){
-      const row = document.querySelector(`tr#${id}`);
+      const row = document.querySelector(`tbody#${id}`);
       if(!row) continue;
       del++;
-      replaceSortedNames(row,'Trash'+del,/^(maneuver)(?:Trash)?[0-9]+(.+)$/);
+      replaceSortedNames(row,'Trash'+del,/^(effect)(?:Trash)?[0-9]+(.+)$/);
     }
-    maneuverTrashNum = del;
-    if(!del){ document.getElementById('maneuver-trash').style.display = 'none'; }
+    effectTrashNum = del;
+    if(!del){ document.getElementById('effect-trash').style.display = 'none'; }
   }
 })();
 

--- a/_core/lib/nc/edit-chara.pl
+++ b/_core/lib/nc/edit-chara.pl
@@ -28,10 +28,10 @@ $pc{enhanceArmsGrow}   ||= 0;
 $pc{enhanceMutateGrow} ||= 0;
 $pc{enhanceModifyGrow} ||= 0;
 $pc{enhanceAny}       ||= '';
-$pc{maneuverNum}      ||= do {
+$pc{effectNum}      ||= do {
   my $max = 0;
   foreach my $key (keys %pc){
-    if($key =~ /^maneuverName(\d+)$/){
+    if($key =~ /^effectName(\d+)$/){
       my $num = $1;
       $max = $num if $num > $max;
     }
@@ -124,21 +124,17 @@ foreach (@set::groups){
   push @groups, { ID=>$id, NAME=>$name, SELECTED=>($pc{group} eq $id ? 1:0) };
 }
 
-my $maneuver_rows_html = '';
-foreach my $i (1 .. $pc{maneuverNum}){
-  $maneuver_rows_html .= <<"HTML";
-      <tr id="maneuver-row${i}">
-        <td class="handle"></td>
-        <td>@{[ input "maneuverBroken${i}", 'checkbox' ]}</td>
-        <td>@{[ input "maneuverUsed${i}",   'checkbox' ]}</td>
-        <td><select name="maneuverPart${i}">@{[ optionNc "maneuverPart${i}",'スキル','頭','腕','胴','脚' ]}</select></td>
-        <td>@{[ input "maneuverName${i}" ]}</td>
-        <td><select name="maneuverTiming${i}">@{[ optionNc "maneuverTiming${i}",'オート','アクション','ラピッド','ジャッジ','ダメージ','効果参照' ]}</select></td>
-        <td>@{[ input "maneuverCost${i}" ]}</td>
-        <td>@{[ input "maneuverRange${i}" ]}</td>
-        <td>@{[ input "maneuverNote${i}" ]}</td>
-      </tr>
-HTML
+my @effect_rows;
+foreach my $i (1 .. $pc{effectNum}){
+  push @effect_rows, {
+    ID       => $i,
+    PART     => pcEscape(pcUnescape($pc{"effectPart$i"})),
+    NAME     => pcEscape(pcUnescape($pc{"effectName$i"})),
+    TIMING   => pcEscape(pcUnescape($pc{"effectTiming$i"})),
+    COST     => pcEscape(pcUnescape($pc{"effectCost$i"})),
+    RANGE    => pcEscape(pcUnescape($pc{"effectRange$i"})),
+    NOTE     => pcEscape(pcUnescape($pc{"effectNote$i"})),
+  };
 }
 
 my @memory_rows;
@@ -236,8 +232,8 @@ $tmpl->param(
   enhanceAnyArms   => $any_checked{arms},
   enhanceAnyMutate => $any_checked{mutate},
   enhanceAnyModify => $any_checked{modify},
-  maneuverNum   => $pc{maneuverNum},
-  ManeuverRowsHTML => $maneuver_rows_html,
+  effectNum    => $pc{effectNum},
+  EffectRows   => \@effect_rows,
   Groups       => \@groups,
   forbiddenBattle => ($pc{forbidden} eq 'battle' ? 1 : 0),
   forbiddenAll    => ($pc{forbidden} eq 'all'    ? 1 : 0),

--- a/_core/lib/nc/view-chara.pl
+++ b/_core/lib/nc/view-chara.pl
@@ -31,18 +31,16 @@ my $tmpl = HTML::Template->new(
   global_vars       => 1,
 );
 
-$pc{maneuverNum} ||= 3;
-my @maneuvers;
-foreach my $i (1 .. $pc{maneuverNum}){
-  push @maneuvers, {
-    BROKEN => ($pc{"maneuverBroken$i"} ? '☑' : ''),
-    USED   => ($pc{"maneuverUsed$i"}  ? '☑' : ''),
-    PART   => $pc{"maneuverPart$i"},
-    NAME   => $pc{"maneuverName$i"},
-    TIMING => $pc{"maneuverTiming$i"},
-    COST   => $pc{"maneuverCost$i"},
-    RANGE  => $pc{"maneuverRange$i"},
-    NOTE   => $pc{"maneuverNote$i"},
+$pc{effectNum} ||= 0;
+my @effects;
+foreach my $i (1 .. $pc{effectNum}){
+  push @effects, {
+    PART   => $pc{"effectPart$i"},
+    NAME   => $pc{"effectName$i"},
+    TIMING => $pc{"effectTiming$i"},
+    COST   => $pc{"effectCost$i"},
+    RANGE  => $pc{"effectRange$i"},
+    NOTE   => $pc{"effectNote$i"},
   };
 }
 
@@ -88,7 +86,7 @@ $tmpl->param(
   %pc,
   groupName   => $group_name,
   Tags        => \@tags,
-  Maneuvers   => \@maneuvers,
+  Effects     => \@effects,
   MemoryRows  => \@memory_rows,
   FetterRows  => \@fetter_rows,
   enhanceAnyArms   => $enhance_any_mark{arms},

--- a/_core/skin/nc/css/chara.css
+++ b/_core/skin/nc/css/chara.css
@@ -33,15 +33,48 @@ article {
   margin: 0;
 }
 
-#maneuvers table,
+
+#effect table,
 #enhancement table {
   width: 100%;
   border-collapse: collapse;
 }
 
-#maneuvers th, #maneuvers td {
+#effect table th,
+#effect table td {
   border: 1px solid #aaa;
   padding: .2rem .4rem;
+}
+
+#effect table thead th:nth-child(n+4) {
+  font-size: 90%;
+}
+
+#effect table tbody td:nth-child(n+2) {
+  font-family: var(--font-proportional);
+  font-feature-settings: "palt";
+}
+
+#effect table tbody td:nth-child(3) { font-weight: bold; }
+#effect table tbody td:nth-child(4),
+#effect table tbody td:nth-child(5),
+#effect table tbody td:nth-child(6) {
+  font-size: 90%;
+}
+
+#effect table tbody td.note {
+  padding-left: .5rem;
+  display: none;
+}
+
+#effect[data-full-open="true"] table tbody td.note,
+#effect table tbody:hover td.note {
+  display: table-cell;
+}
+
+#effect table tbody td.note span.right {
+  float: right;
+  font-size: 90%;
 }
 
 #free-note {

--- a/_core/skin/nc/edit-chara.html
+++ b/_core/skin/nc/edit-chara.html
@@ -173,53 +173,50 @@
     <TMPL_VAR imageForm>
   </div>
 </section>
-<section id="maneuvers" class="box">
-  <h2>マニューバ</h2>
-  <input type="hidden" name="maneuverNum" value="<TMPL_VAR maneuverNum>">
-  <table class="edit-table line-tbody no-border-cells" id="maneuver-table">
-    <thead>
-      <tr><th><th>破損<th>使用<th>部位<th>名称<th>タイミング<th>コスト<th>射程<th class="left">効果</tr>
+<section id="effect" class="box">
+  <h2>エフェクト</h2>
+  <input type="hidden" name="effectNum" value="<TMPL_VAR effectNum>">
+  <table class="edit-table line-tbody no-border-cells" id="effect-table">
+    <thead id="effect-head">
+      <tr><th><th>部位<th>名称<th>タイミング<th>コスト<th>射程</tr>
     </thead>
-    <tbody id="maneuver-list">
-<TMPL_VAR ManeuverRowsHTML>
+<TMPL_LOOP EffectRows>
+    <tbody id="effect-row<TMPL_VAR ID>">
+      <tr>
+        <td rowspan="2" class="handle"></td>
+        <td><input type="text" name="effect<TMPL_VAR ID>Part" value="<TMPL_VAR PART>" placeholder="部位" list="list-part"></td>
+        <td><input type="text" name="effect<TMPL_VAR ID>Name" value="<TMPL_VAR NAME>" placeholder="名称"></td>
+        <td><input type="text" name="effect<TMPL_VAR ID>Timing" value="<TMPL_VAR TIMING>" placeholder="タイミング" list="list-timing"></td>
+        <td><input type="text" name="effect<TMPL_VAR ID>Cost" value="<TMPL_VAR COST>" placeholder="コスト" list="list-cost"></td>
+        <td><input type="text" name="effect<TMPL_VAR ID>Range" value="<TMPL_VAR RANGE>" placeholder="射程" list="list-range"></td>
+      </tr>
+      <tr>
+        <td class="note" colspan="5"><input type="text" name="effect<TMPL_VAR ID>Note" value="<TMPL_VAR NOTE>" placeholder="効果"></td>
+      </tr>
     </tbody>
+</TMPL_LOOP>
   </table>
-  <div class="add-del-button"><a onclick="addManeuver()">▼</a><a onclick="delManeuver()">▲</a></div>
-  <template id="maneuver-template">
-    <tr id="maneuver-rowTMPL">
-      <td class="handle"></td>
-      <td><input type="checkbox" name="maneuverBrokenTMPL"></td>
-      <td><input type="checkbox" name="maneuverUsedTMPL"></td>
-      <td>
-        <select name="maneuverPartTMPL">
-          <option value="スキル">スキル</option>
-          <option value="頭">頭</option>
-          <option value="腕">腕</option>
-          <option value="胴">胴</option>
-          <option value="脚">脚</option>
-        </select>
-      </td>
-      <td><input type="text" name="maneuverNameTMPL"></td>
-      <td>
-        <select name="maneuverTimingTMPL">
-          <option value="オート">オート</option>
-          <option value="アクション">アクション</option>
-          <option value="ラピッド">ラピッド</option>
-          <option value="ジャッジ">ジャッジ</option>
-          <option value="ダメージ">ダメージ</option>
-          <option value="効果参照">効果参照</option>
-        </select>
-      </td>
-      <td><input type="text" name="maneuverCostTMPL"></td>
-      <td><input type="text" name="maneuverRangeTMPL"></td>
-      <td><input type="text" name="maneuverNoteTMPL"></td>
-    </tr>
+  <div class="add-del-button"><a onclick="addEffect()">▼</a><a onclick="delEffect()">▲</a></div>
+  <template id="effect-template">
+    <tbody id="effect-rowTMPL">
+      <tr>
+        <td rowspan="2" class="handle"></td>
+        <td><input type="text" name="effectPartTMPL" placeholder="部位" list="list-part"></td>
+        <td><input type="text" name="effectNameTMPL" placeholder="名称"></td>
+        <td><input type="text" name="effectTimingTMPL" placeholder="タイミング" list="list-timing"></td>
+        <td><input type="text" name="effectCostTMPL" placeholder="コスト" list="list-cost"></td>
+        <td><input type="text" name="effectRangeTMPL" placeholder="射程" list="list-range"></td>
+      </tr>
+      <tr>
+        <td class="note" colspan="5"><input type="text" name="effectNoteTMPL" placeholder="効果"></td>
+      </tr>
+    </tbody>
   </template>
 </section>
-<div class="box trash-box" id="maneuver-trash">
-  <h2><span class="material-symbols-outlined">delete</span><span class="shorten">削除マニューバ</span></h2>
-  <table class="edit-table line-tbody" id="maneuver-trash-table"></table>
-  <i class="material-symbols-outlined close-button" onclick="document.getElementById('maneuver-trash').style.display = 'none';">close</i>
+<div class="box trash-box" id="effect-trash">
+  <h2><span class="material-symbols-outlined">delete</span><span class="shorten">削除エフェクト</span></h2>
+  <table class="edit-table line-tbody" id="effect-trash-table"></table>
+  <i class="material-symbols-outlined close-button" onclick="document.getElementById('effect-trash').style.display = 'none';">close</i>
 </div>
 <section id="memory" class="box">
   <h2>記憶のカケラ</h2>
@@ -273,6 +270,42 @@
 </form>
 <div class="back-button"><a href="./">⏎</a></div>
 </main>
+<datalist id="list-timing">
+  <option value="オート">
+  <option value="アクション">
+  <option value="ラピッド">
+  <option value="ジャッジ">
+  <option value="ダメージ">
+  <option value="効果参照">
+</datalist>
+<datalist id="list-part">
+  <option value="スキル">
+  <option value="頭">
+  <option value="腕">
+  <option value="胴">
+  <option value="脚">
+</datalist>
+<datalist id="list-cost">
+  <option value="なし">
+  <option value="0">
+  <option value="1">
+  <option value="2">
+  <option value="3">
+  <option value="4">
+  <option value="効果参照">
+</datalist>
+<datalist id="list-range">
+  <option value="自身">
+  <option value="0">
+  <option value="0～1">
+  <option value="0～2">
+  <option value="0～3">
+  <option value="1">
+  <option value="1～2">
+  <option value="1～3">
+  <option value="2～3">
+  <option value="効果参照">
+</datalist>
 <script src="<TMPL_VAR coreDir>/lib/edit.js?<TMPL_VAR ver>" defer></script>
 <script src="<TMPL_VAR coreDir>/lib/nc/edit-chara.js?<TMPL_VAR ver>" defer></script>
 <script>

--- a/_core/skin/nc/sheet-chara.html
+++ b/_core/skin/nc/sheet-chara.html
@@ -90,28 +90,35 @@
     </div>
   </div>
 
-  <section id="maneuvers" class="box">
-    <h2>マニューバ</h2>
-    <table>
+  <section class="box effects" id="effect">
+    <h2>エフェクト</h2>
+    <button class="open-button" onclick="switchEffectNoteFullOpen();" data-open="" data-text-open="効果を全展開" data-text-close="効果を折畳む"></button>
+    <table class="data-table line-tbody">
       <thead>
-        <tr><th>破損<th>使用<th>部位<th>名称<th>タイミング<th>コスト<th>射程<th>効果</tr>
+        <tr><th>部位<th>名称<th>タイミング<th>コスト<th>射程</tr>
       </thead>
-      <tbody>
-        <TMPL_LOOP Maneuvers>
+      <TMPL_LOOP Effects><tbody>
         <tr>
-          <td><TMPL_VAR BROKEN></td>
-          <td><TMPL_VAR USED></td>
-          <td><TMPL_VAR PART></td>
-          <td><TMPL_VAR NAME></td>
+          <td rowspan="2"><TMPL_VAR PART></td>
+          <td class="name"><TMPL_VAR NAME></td>
           <td><TMPL_VAR TIMING></td>
           <td><TMPL_VAR COST></td>
           <td><TMPL_VAR RANGE></td>
-          <td><TMPL_VAR NOTE></td>
         </tr>
-        </TMPL_LOOP>
-      </tbody>
+        <tr>
+          <td class="note" colspan="5"><TMPL_VAR NOTE></td>
+        </tr>
+      </TMPL_LOOP>
     </table>
   </section>
+  <script>
+    let effectFullOpen = false;
+    function switchEffectNoteFullOpen(){
+      effectFullOpen = !effectFullOpen;
+      document.getElementById('effect').dataset.fullOpen = effectFullOpen ? 'true' : '';
+      document.querySelector('#effect .open-button').dataset.open = effectFullOpen ? 'true' : '';
+    }
+  </script>
 
   <section id="memory" class="box">
     <h2>記憶のカケラ</h2>


### PR DESCRIPTION
## Summary
- allow effect input fields to use datalist suggestions like DX3
- add timing/skill/etc datalists to nc edit page
- refine effect fields: remove LV/difficulty/etc and add part & cost

## Testing
- `perl -c _core/lib/nc/edit-chara.pl` *(fails: HTML::Template missing)*
- `perl -c _core/lib/nc/view-chara.pl` *(fails: HTML::Template missing)*
- `perl -c _core/lib/nc/calc-chara.pl`

------
https://chatgpt.com/codex/tasks/task_e_684d92c7efa88330bf30bb1545f2b38e