### PR TITLE
Fix nc edit rows output

### DIFF
--- a/_core/skin/nc/edit-chara.html
+++ b/_core/skin/nc/edit-chara.html
@@ -17,7 +17,7 @@
   <h1><a href="./"><TMPL_VAR title></a></h1>
   <nav>
     <ul>
-      <TMPL_LOOP Menu><li class="<TMPL_VAR SIZE>"><a <TMPL_VAR TYPE>="<TMPL_VAR VALUE>"><TMPL_VAR TEXT></a></TMPL_LOOP>
+      <TMPL_VAR MenuHTML ESCAPE=0>
       <li><a onclick="nightModeChange()" class="nightmode-icon" title="ナイトモード"></a>
     </ul>
   </nav>
@@ -59,7 +59,7 @@
 <div class="box" id="group">
   <dl>
     <dt>グループ<dd><select name="group">
-      <TMPL_LOOP Groups><option value="<TMPL_VAR ID>"<TMPL_IF SELECTED> selected</TMPL_IF>><TMPL_VAR NAME></option></TMPL_LOOP>
+      <TMPL_VAR GroupsHTML ESCAPE=0>
     </select>
     <dt>タグ<dd><input type="text" name="tags" value="<TMPL_VAR tags>">
   </dl>
@@ -180,21 +180,7 @@
     <thead id="effect-head">
       <tr><th><th>部位<th>名称<th>タイミング<th>コスト<th>射程</tr>
     </thead>
-<TMPL_LOOP EffectRows>
-    <tbody id="effect-row<TMPL_VAR ID>">
-      <tr>
-        <td rowspan="2" class="handle"></td>
-        <td><input type="text" name="effectPart<TMPL_VAR ID>" value="<TMPL_VAR PART>" placeholder="部位" list="list-part"></td>
-        <td><input type="text" name="effectName<TMPL_VAR ID>" value="<TMPL_VAR NAME>" placeholder="名称"></td>
-        <td><input type="text" name="effectTiming<TMPL_VAR ID>" value="<TMPL_VAR TIMING>" placeholder="タイミング" list="list-timing"></td>
-        <td><input type="text" name="effectCost<TMPL_VAR ID>" value="<TMPL_VAR COST>" placeholder="コスト" list="list-cost"></td>
-        <td><input type="text" name="effectRange<TMPL_VAR ID>" value="<TMPL_VAR RANGE>" placeholder="射程" list="list-range"></td>
-      </tr>
-      <tr>
-        <td class="note" colspan="5"><input type="text" name="effectNote<TMPL_VAR ID>" value="<TMPL_VAR NOTE>" placeholder="効果"></td>
-      </tr>
-    </tbody>
-</TMPL_LOOP>
+<TMPL_VAR EffectRowsHTML ESCAPE=0>
   </table>
   <div class="add-del-button"><a onclick="addEffect()">▼</a><a onclick="delEffect()">▲</a></div>
   <template id="effect-template">
@@ -226,12 +212,7 @@
       <tr><th>名称<th class="left">内容</tr>
     </thead>
     <tbody id="memory-list">
-<TMPL_LOOP MemoryRows>
-      <tr id="memory-row<TMPL_VAR ID>">
-        <td><input type="text" name="memoryName<TMPL_VAR ID>" value="<TMPL_VAR NAME>"></td>
-        <td><input type="text" name="memoryNote<TMPL_VAR ID>" value="<TMPL_VAR NOTE>"></td>
-      </tr>
-</TMPL_LOOP>
+<TMPL_VAR MemoryRowsHTML ESCAPE=0>
     </tbody>
   </table>
   <div class="add-del-button"><a onclick="addMemory()">▼</a><a onclick="delMemory()">▲</a></div>
@@ -249,15 +230,7 @@
       <tr><th>対象<th>未練<th>狂気点<th>発狂効果<th>発狂内容</tr>
     </thead>
     <tbody>
-<TMPL_LOOP FetterRows>
-      <tr>
-        <td><input type="text" name="fetterTarget<TMPL_VAR ID>" value="<TMPL_VAR TARGET>"></td>
-        <td><span class="fetter-to">への</span><select name="fetterNote<TMPL_VAR ID>" data-value="<TMPL_VAR NOTE>" oninput="setFetter(<TMPL_VAR ID>)"></select></td>
-        <td><input type="number" name="fetterPoint<TMPL_VAR ID>" value="<TMPL_VAR POINT>" min="0" max="4"></td>
-        <td><input type="text" name="fetterEffect<TMPL_VAR ID>" value="<TMPL_VAR EFFECT>" readonly></td>
-        <td><input type="text" name="fetterEffectNote<TMPL_VAR ID>" value="<TMPL_VAR EFFECT_NOTE>"></td>
-      </tr>
-</TMPL_LOOP>
+<TMPL_VAR FetterRowsHTML ESCAPE=0>
     </tbody>
   </table>
 </section>


### PR DESCRIPTION
## Summary
- fix NC edit screen to output menu/options/effect/memory/fetter rows directly from perl
- update HTML template variables accordingly

## Testing
- `perl -c _core/lib/nc/edit-chara.pl` *(fails: Can't locate HTML/Template.pm)*

------
https://chatgpt.com/codex/tasks/task_e_684d8ff3f6d48330ae15240ae35ab760