### PR TITLE
Align NC effect field naming with DX3rd style

### DIFF
--- a/_core/lib/nc/calc-chara.pl
+++ b/_core/lib/nc/calc-chara.pl
@@ -21,12 +21,12 @@ sub data_calc {
   }
 
   foreach my $i (1 .. $pc{effectNum}){
-    $pc{"effectPart$i"}   ||= '';
-    $pc{"effectName$i"}   ||= '';
-    $pc{"effectTiming$i"} ||= '';
-    $pc{"effectCost$i"}   ||= '';
-    $pc{"effectRange$i"}  ||= '';
-    $pc{"effectNote$i"}   ||= '';
+    $pc{"effect${i}Part"}   ||= '';
+    $pc{"effect${i}Name"}   ||= '';
+    $pc{"effect${i}Timing"} ||= '';
+    $pc{"effect${i}Cost"}   ||= '';
+    $pc{"effect${i}Range"}  ||= '';
+    $pc{"effect${i}Note"}   ||= '';
   }
 
   ### 未練／狂気

--- a/_core/lib/nc/edit-chara.pl
+++ b/_core/lib/nc/edit-chara.pl
@@ -31,7 +31,7 @@ $pc{enhanceAny}       ||= '';
 $pc{effectNum}      ||= do {
   my $max = 0;
   foreach my $key (keys %pc){
-    if($key =~ /^effectName(\d+)$/){
+    if($key =~ /^effect(\d+)Name$/){
       my $num = $1;
       $max = $num if $num > $max;
     }
@@ -129,24 +129,24 @@ my $menu_html = qq{<li class="small"><a href="./">一覧へ</a>};
 
 my $effect_rows_html = '';
 foreach my $i (1 .. $pc{effectNum}){
-  my $part   = pcEscape(pcUnescape($pc{"effectPart$i"}));
-  my $name   = pcEscape(pcUnescape($pc{"effectName$i"}));
-  my $timing = pcEscape(pcUnescape($pc{"effectTiming$i"}));
-  my $cost   = pcEscape(pcUnescape($pc{"effectCost$i"}));
-  my $range  = pcEscape(pcUnescape($pc{"effectRange$i"}));
-  my $note   = pcEscape(pcUnescape($pc{"effectNote$i"}));
+  my $part   = pcEscape(pcUnescape($pc{"effect${i}Part"}));
+  my $name   = pcEscape(pcUnescape($pc{"effect${i}Name"}));
+  my $timing = pcEscape(pcUnescape($pc{"effect${i}Timing"}));
+  my $cost   = pcEscape(pcUnescape($pc{"effect${i}Cost"}));
+  my $range  = pcEscape(pcUnescape($pc{"effect${i}Range"}));
+  my $note   = pcEscape(pcUnescape($pc{"effect${i}Note"}));
   $effect_rows_html .= qq{
     <tbody id="effect-row$i">
       <tr>
         <td rowspan="2" class="handle"></td>
-        <td><input type="text" name="effectPart$i" value="$part" placeholder="部位" list="list-part"></td>
-        <td><input type="text" name="effectName$i" value="$name" placeholder="名称"></td>
-        <td><input type="text" name="effectTiming$i" value="$timing" placeholder="タイミング" list="list-timing"></td>
-        <td><input type="text" name="effectCost$i" value="$cost" placeholder="コスト" list="list-cost"></td>
-        <td><input type="text" name="effectRange$i" value="$range" placeholder="射程" list="list-range"></td>
+        <td><input type="text" name="effect${i}Part" value="$part" placeholder="部位" list="list-part"></td>
+        <td><input type="text" name="effect${i}Name" value="$name" placeholder="名称"></td>
+        <td><input type="text" name="effect${i}Timing" value="$timing" placeholder="タイミング" list="list-timing"></td>
+        <td><input type="text" name="effect${i}Cost" value="$cost" placeholder="コスト" list="list-cost"></td>
+        <td><input type="text" name="effect${i}Range" value="$range" placeholder="射程" list="list-range"></td>
       </tr>
       <tr>
-        <td class="note" colspan="5"><input type="text" name="effectNote$i" value="$note" placeholder="効果"></td>
+        <td class="note" colspan="5"><input type="text" name="effect${i}Note" value="$note" placeholder="効果"></td>
       </tr>
     </tbody>
   };

--- a/_core/lib/nc/view-chara.pl
+++ b/_core/lib/nc/view-chara.pl
@@ -35,12 +35,12 @@ $pc{effectNum} ||= 0;
 my @effects;
 foreach my $i (1 .. $pc{effectNum}){
   push @effects, {
-    PART   => $pc{"effectPart$i"},
-    NAME   => $pc{"effectName$i"},
-    TIMING => $pc{"effectTiming$i"},
-    COST   => $pc{"effectCost$i"},
-    RANGE  => $pc{"effectRange$i"},
-    NOTE   => $pc{"effectNote$i"},
+    PART   => $pc{"effect${i}Part"},
+    NAME   => $pc{"effect${i}Name"},
+    TIMING => $pc{"effect${i}Timing"},
+    COST   => $pc{"effect${i}Cost"},
+    RANGE  => $pc{"effect${i}Range"},
+    NOTE   => $pc{"effect${i}Note"},
   };
 }
 

--- a/_core/skin/nc/edit-chara.html
+++ b/_core/skin/nc/edit-chara.html
@@ -187,14 +187,14 @@
     <tbody id="effect-rowTMPL">
       <tr>
         <td rowspan="2" class="handle"></td>
-        <td><input type="text" name="effectPartTMPL" placeholder="部位" list="list-part"></td>
-        <td><input type="text" name="effectNameTMPL" placeholder="名称"></td>
-        <td><input type="text" name="effectTimingTMPL" placeholder="タイミング" list="list-timing"></td>
-        <td><input type="text" name="effectCostTMPL" placeholder="コスト" list="list-cost"></td>
-        <td><input type="text" name="effectRangeTMPL" placeholder="射程" list="list-range"></td>
+        <td><input type="text" name="effectTMPLPart" placeholder="部位" list="list-part"></td>
+        <td><input type="text" name="effectTMPLName" placeholder="名称"></td>
+        <td><input type="text" name="effectTMPLTiming" placeholder="タイミング" list="list-timing"></td>
+        <td><input type="text" name="effectTMPLCost" placeholder="コスト" list="list-cost"></td>
+        <td><input type="text" name="effectTMPLRange" placeholder="射程" list="list-range"></td>
       </tr>
       <tr>
-        <td class="note" colspan="5"><input type="text" name="effectNoteTMPL" placeholder="効果"></td>
+        <td class="note" colspan="5"><input type="text" name="effectTMPLNote" placeholder="効果"></td>
       </tr>
     </tbody>
   </template>


### PR DESCRIPTION
## Summary
- rename Nechronica effect fields to use `effect{n}Name` style instead of `effectName{n}`
- update initialization and templates accordingly

## Testing
- `perl -c _core/lib/nc/calc-chara.pl`
- `perl -c _core/lib/nc/edit-chara.pl`
- `perl -c _core/lib/nc/view-chara.pl`


------
https://chatgpt.com/codex/tasks/task_e_684dfbfe2de8833084627f851cc70e6b